### PR TITLE
Add segmented scoring for odor and post-odor intervals

### DIFF
--- a/label_videos.py
+++ b/label_videos.py
@@ -17,6 +17,19 @@ METRIC_WEIGHTS = {
     'time_fraction': 1.0,   # fraction of frames above THRESHOLD
     'auc': 1.0              # integral above THRESHOLD (scaled by global max)
 }
+
+SEGMENTS = {
+    'odor': {
+        'label': 'During odor',
+        'duration_seconds': 60.0
+    },
+    'post': {
+        'label': '30s after odor',
+        'duration_seconds': 30.0
+    }
+}
+
+TOTAL_DISPLAY_SECONDS = sum(seg['duration_seconds'] for seg in SEGMENTS.values())
 # ===============================================================
 
 def compute_metrics(signal, fps):
@@ -93,7 +106,8 @@ def main():
     videos = []
     for root,_,files in os.walk(args.videos):
         for f in files:
-            if f.lower().endswith(video_exts):
+            fname_lower = f.lower()
+            if fname_lower.endswith(video_exts) and 'testing' in fname_lower:
                 videos.append(os.path.join(root,f))
     videos.sort()
     if not videos:
@@ -105,11 +119,14 @@ def main():
     if args.data:
         for root,_,files in os.walk(args.data):
             for f in files:
-                if f.lower().endswith(".csv"):
+                fname_lower = f.lower()
+                if fname_lower.endswith(".csv") and 'testing' in fname_lower:
                     data_map[os.path.splitext(f)[0]] = os.path.join(root,f)
 
     def csv_for(video_path):
         base = os.path.splitext(os.path.basename(video_path))[0]
+        if 'testing' not in base.lower():
+            return None
         if base in data_map:
             return data_map[base]
         candidate = os.path.join(os.path.dirname(video_path), base + ".csv")
@@ -117,7 +134,7 @@ def main():
 
     # Precompute metrics + global max AUC for scaling
     items = []
-    global_max_auc = 0.0
+    global_max_auc = {key: 0.0 for key in SEGMENTS}
     for vp in videos:
         cp = csv_for(vp)
         if cp is None or not os.path.exists(cp):
@@ -129,22 +146,65 @@ def main():
             print(f"[WARN] Failed reading {cp}: {e}")
             continue
 
-        # FPS from video (fallback 30)
         cap = cv2.VideoCapture(vp)
-        fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+        if not cap.isOpened():
+            print(f"[WARN] Cannot open video {vp}, skipping.")
+            cap.release()
+            continue
+        fps_val = cap.get(cv2.CAP_PROP_FPS)
+        fps = float(fps_val) if fps_val and fps_val > 0 else 30.0
+        frame_count_val = cap.get(cv2.CAP_PROP_FRAME_COUNT)
+        frame_count = int(frame_count_val) if frame_count_val and frame_count_val > 0 else None
         cap.release()
 
         sig = choose_signal_column(df)
-        m = compute_metrics(sig, fps)
-        if m is None:
-            print(f"[WARN] No metrics for {vp}, skipping.")
+        fps_for_calc = fps if fps and fps > 0 else 30.0
+        segment_metrics = {}
+        signal_limit_frames = len(sig)
+        frames_total_display = int(round(fps_for_calc * TOTAL_DISPLAY_SECONDS)) if fps_for_calc > 0 else 0
+        if frames_total_display > 0:
+            signal_limit_frames = min(signal_limit_frames, frames_total_display)
+
+        start_idx = 0
+        segment_items = list(SEGMENTS.items())
+        for seg_idx, (seg_key, seg_cfg) in enumerate(segment_items):
+            seg_frames = int(round(fps_for_calc * seg_cfg['duration_seconds'])) if fps_for_calc > 0 else 0
+            if seg_idx == len(segment_items) - 1 and signal_limit_frames > start_idx:
+                end_idx = signal_limit_frames
+            else:
+                end_idx = start_idx + seg_frames if seg_frames > 0 else start_idx
+                if signal_limit_frames >= 0:
+                    end_idx = min(signal_limit_frames, end_idx)
+            if end_idx < start_idx:
+                end_idx = start_idx
+            seg_signal = sig[start_idx:end_idx]
+            start_idx = end_idx
+            metrics = compute_metrics(seg_signal, fps_for_calc) if len(seg_signal) else None
+            if metrics:
+                global_max_auc[seg_key] = max(global_max_auc[seg_key], metrics['auc'])
+            segment_metrics[seg_key] = metrics
+
+        max_frames = int(round(fps_for_calc * TOTAL_DISPLAY_SECONDS)) if fps_for_calc > 0 else 0
+        if frame_count is not None:
+            max_frames = min(max_frames, frame_count) if max_frames > 0 else frame_count
+        if max_frames <= 0:
+            max_frames = frames_total_display if frames_total_display > 0 else signal_limit_frames
+        if max_frames <= 0:
+            print(f"[WARN] No playable frames for {vp}, skipping.")
             continue
 
-        m['video_path'] = vp
-        m['csv_path'] = cp
-        m['fly_id'], m['trial_id'] = parse_fly_trial(vp)
-        items.append(m)
-        global_max_auc = max(global_max_auc, m['auc'])
+        item = {
+            'video_path': vp,
+            'csv_path': cp,
+            'fly_id': None,
+            'trial_id': None,
+            'segments': segment_metrics,
+            'fps': fps_for_calc,
+            'max_frames': max_frames,
+            'display_duration': min(TOTAL_DISPLAY_SECONDS, max_frames / fps_for_calc if fps_for_calc > 0 else TOTAL_DISPLAY_SECONDS)
+        }
+        item['fly_id'], item['trial_id'] = parse_fly_trial(vp)
+        items.append(item)
 
     if not items:
         print("Nothing to score (no metric-bearing pairs).")
@@ -168,16 +228,21 @@ def main():
     canvas = tk.Canvas(root, width=max_w, height=max_h, bg="black")
     canvas.pack()
 
-    info = tk.Label(root, text="Watch the video. Select 0 (NR) … 10 (Strongest). Submit to reveal data metrics.")
+    info = tk.Label(root, text="Watch the first 90 seconds. Score each interval 0 (NR) … 10 (Strongest). Submit to reveal data metrics.")
     info.pack(pady=6)
 
     # Rating row
     rating_frame = tk.Frame(root)
-    rating_frame.pack(pady=4)
-    score_var = tk.IntVar(value=-1)
+    rating_frame.pack(pady=4, fill="x")
+    score_vars = {}
     labels = [("0 (NR)",0),("1",1),("2",2),("3",3),("4",4),("5 (Average)",5),("6",6),("7",7),("8",8),("9",9),("10 (Strongest)",10)]
-    for text,val in labels:
-        tk.Radiobutton(rating_frame, text=text, variable=score_var, value=val).pack(side=tk.LEFT)
+    for seg_key, seg_cfg in SEGMENTS.items():
+        seg_frame = tk.LabelFrame(rating_frame, text=seg_cfg['label'])
+        seg_frame.pack(fill="x", pady=2)
+        var = tk.IntVar(value=-1)
+        score_vars[seg_key] = var
+        for text,val in labels:
+            tk.Radiobutton(seg_frame, text=text, variable=var, value=val).pack(side=tk.LEFT)
 
     # Buttons
     btns = tk.Frame(root); btns.pack(pady=4)
@@ -198,105 +263,156 @@ def main():
     cap = None
     fps = 30.0
     playing = False
+    frame_counter = 0
+    current_max_frames = 0
 
     def play(index):
-        nonlocal cap, fps, playing
+        nonlocal cap, fps, playing, frame_counter, current_max_frames
         if cap: cap.release()
-        vp = items[index]['video_path']
+        item = items[index]
+        vp = item['video_path']
         cap = cv2.VideoCapture(vp)
         if not cap.isOpened():
             messagebox.showerror("Error", f"Cannot open video: {vp}")
             return
         fps_val = cap.get(cv2.CAP_PROP_FPS)
-        fps = float(fps_val) if fps_val and fps_val > 0 else 30.0
-        score_var.set(-1)
+        fps = float(fps_val) if fps_val and fps_val > 0 else item['fps']
+        if not fps or fps <= 0:
+            fps = item['fps'] if item['fps'] > 0 else 30.0
+        frame_counter = 0
+        current_max_frames = item['max_frames']
+        for var in score_vars.values():
+            var.set(-1)
         data_lbl.config(text="")
-        info.config(text=f"{os.path.basename(vp)}  [{index+1}/{len(items)}] — rate 0 (NR) to 10 (Strongest)")
+        info.config(text=(
+            f"{os.path.basename(vp)}  [{index+1}/{len(items)}] — "
+            f"rate each interval (0–10). Showing first {item['display_duration']:.1f}s."
+        ))
         playing = True
         root.after(0, advance)
 
     def advance():
-        nonlocal playing, cap, fps
+        nonlocal playing, cap, fps, frame_counter, current_max_frames
         if not playing or cap is None:
             return
-        ok, frame = cap.read()
-        if ok:
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            im = Image.fromarray(frame)
-            imgtk = ImageTk.PhotoImage(image=im)
-            canvas.imgtk = imgtk
-            canvas.create_image(0,0,anchor=tk.NW,image=imgtk)
-            root.after(int(1000/max(1.0,fps)), advance)
-        else:
+        if current_max_frames and frame_counter >= current_max_frames:
             playing = False
+            return
+        ok, frame = cap.read()
+        if not ok:
+            playing = False
+            return
+        frame_counter += 1
+        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        im = Image.fromarray(frame)
+        imgtk = ImageTk.PhotoImage(image=im)
+        canvas.imgtk = imgtk
+        canvas.create_image(0,0,anchor=tk.NW,image=imgtk)
+        if current_max_frames and frame_counter >= current_max_frames:
+            playing = False
+            return
+        delay = int(1000/max(1.0,fps))
+        root.after(delay, advance)
 
     def on_replay():
-        nonlocal cap, playing
+        nonlocal cap, playing, frame_counter
         if not cap: return
         cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+        frame_counter = 0
         if not playing:
             playing = True
             root.after(0, advance)
 
     def on_submit():
         nonlocal playing
-        if score_var.get() == -1:
-            messagebox.showwarning("Select a score", "Please select 0–10 before submitting.")
+        missing = [seg_cfg['label'] for seg_key, seg_cfg in SEGMENTS.items() if score_vars[seg_key].get() == -1]
+        if missing:
+            messagebox.showwarning("Select scores", f"Please score each interval: {', '.join(missing)}")
             return
         playing = False
         it = items[idx]
-        time_frac = it['time_fraction']
-        auc_val   = it['auc']
-
-        # Scale metrics to 0–10
-        m_parts = {}
-        m_parts['time_fraction'] = max(0.0, min(10.0, time_frac * 10.0))
-        m_parts['auc'] = max(0.0, min(10.0, (auc_val / global_max_auc * 10.0) if global_max_auc > 0 else 0.0))
-
-        # Weighted average
-        wsum = 0.0; score_sum = 0.0
-        for k,w in METRIC_WEIGHTS.items():
-            if k in m_parts:
-                score_sum += float(w) * float(m_parts[k])
-                wsum += float(w)
-        data_score = int(round(score_sum / wsum)) if wsum > 0 else 0
-
-        user_score = int(score_var.get())
-        combined = (user_score + data_score) / 2.0
-
         fly_id, trial_id = it.get('fly_id'), it.get('trial_id')
 
-        results.append({
+        segment_results = {}
+        lines = []
+        for seg_key, seg_cfg in SEGMENTS.items():
+            metrics = it['segments'].get(seg_key)
+            user_score = int(score_vars[seg_key].get())
+            duration = metrics['duration'] if metrics else 0.0
+            time_fraction = metrics['time_fraction'] if metrics else 0.0
+            auc_val = metrics['auc'] if metrics else 0.0
+
+            # Scale metrics to 0–10
+            if metrics:
+                m_parts = {
+                    'time_fraction': max(0.0, min(10.0, time_fraction * 10.0)),
+                    'auc': max(0.0, min(10.0, (auc_val / global_max_auc[seg_key] * 10.0) if global_max_auc[seg_key] > 0 else 0.0))
+                }
+            else:
+                m_parts = {'time_fraction': 0.0, 'auc': 0.0}
+
+            wsum = 0.0
+            score_sum = 0.0
+            for k, w in METRIC_WEIGHTS.items():
+                if k in m_parts:
+                    score_sum += float(w) * float(m_parts[k])
+                    wsum += float(w)
+            data_score = int(round(score_sum / wsum)) if wsum > 0 else 0
+            combined = (user_score + data_score) / 2.0
+
+            time_above = time_fraction * duration
+            pct = time_fraction * 100.0
+            if metrics:
+                lines.append(
+                    f"{seg_cfg['label']}:\n"
+                    f"  Time above threshold: {time_above:.2f}s ({pct:.1f}%)\n"
+                    f"  AUC over threshold: {auc_val:.3f}\n"
+                    f"  Data-suggested score: {data_score}"
+                )
+            else:
+                lines.append(f"{seg_cfg['label']}: No data available for this interval.")
+
+            segment_results[seg_key] = {
+                'user_score': user_score,
+                'data_score': data_score,
+                'combined_score': combined,
+                'time_fraction': time_fraction,
+                'auc': auc_val,
+                'duration': duration,
+                'time_above_threshold': time_above
+            }
+
+        row = {
             "fly_id": fly_id,
             "trial_id": trial_id,
             "video_file": os.path.basename(it['video_path']),
             "csv_file": os.path.basename(it['csv_path']),
-            "user_score": user_score,
-            "data_score": data_score,
-            "combined_score": combined,
-            "time_fraction": time_frac,
-            "auc": auc_val,
-            "duration": it['duration']
-        })
+            "display_duration_seconds": it['display_duration']
+        }
+        for seg_key, seg_res in segment_results.items():
+            row[f"user_score_{seg_key}"] = seg_res['user_score']
+            row[f"data_score_{seg_key}"] = seg_res['data_score']
+            row[f"combined_score_{seg_key}"] = seg_res['combined_score']
+            row[f"time_fraction_{seg_key}"] = seg_res['time_fraction']
+            row[f"auc_{seg_key}"] = seg_res['auc']
+            row[f"time_above_threshold_{seg_key}"] = seg_res['time_above_threshold']
+            row[f"segment_duration_{seg_key}"] = seg_res['duration']
 
-        # Reveal metrics
-        secs = time_frac * it['duration']
-        pct = time_frac * 100.0
-        data_lbl.config(text=(
-            f"Time above threshold: {secs:.2f}s ({pct:.1f}%)\n"
-            f"AUC over threshold: {auc_val:.3f}\n"
-            f"Data-suggested score: {data_score}"
-        ))
+        results.append(row)
+
+        data_lbl.config(text="\n\n".join(lines))
 
         submit_btn.config(state=tk.DISABLED)
         next_btn.config(state=tk.NORMAL)
 
     def on_next():
-        nonlocal idx
+        nonlocal idx, cap
         idx += 1
         if idx >= len(items):
             out = args.output
             pd.DataFrame(results).to_csv(out, index=False)
+            if cap:
+                cap.release()
             messagebox.showinfo("Done", f"All videos scored.\nSaved: {out}")
             root.destroy()
             return


### PR DESCRIPTION
## Summary
- restrict labeling to video/CSV pairs that include "testing" in their names
- limit playback to the first 90 seconds and compute metrics for odor and post-odor windows
- collect separate user/data scores per interval and export the expanded results table

## Testing
- python -m compileall label_videos.py

------
https://chatgpt.com/codex/tasks/task_e_68dacea954bc832da8a9b1ab15ce2309