### PR TITLE
Add matrix-driven envelope support to label_videos

### DIFF
--- a/label_videos.py
+++ b/label_videos.py
@@ -1,14 +1,8 @@
-import os
-import sys
-import argparse
+import os, sys, argparse, json, re
 import tkinter as tk
-from tkinter import messagebox
-from tkinter import ttk
-import cv2
-import numpy as np
-import pandas as pd
+from tkinter import messagebox, ttk
+import cv2, numpy as np, pandas as pd
 from PIL import Image, ImageTk
-import re
 
 # =================== CONFIG (edit as needed) ===================
 METRIC_WEIGHTS = {
@@ -175,8 +169,17 @@ def parse_fly_trial(path):
 def main():
     ap = argparse.ArgumentParser(description="Label fly behavior videos (0–10) and compute data-driven scores.")
     ap.add_argument("-v","--videos", required=True, help="Folder with videos (recursively scanned).")
-    ap.add_argument("-d","--data", default=None, help="Folder with CSV traces (if not next to videos).")
+    # Legacy CSV input is now optional/unused; kept for backward compatibility.
+    ap.add_argument("-d","--data", default=None, help="(Deprecated) Folder with CSV traces. If provided and matrix row not found, will fallback.")
     ap.add_argument("-o","--output", default="scoring_results.csv", help="Output master CSV.")
+    # NEW: matrix + maps supplied explicitly
+    ap.add_argument("--matrix", required=True, help="Path to envelope matrix .npy (float16) file.")
+    ap.add_argument("--codes",  required=True, help="Path to code_maps.json (column order + code maps).")
+    # Optional overrides
+    ap.add_argument("--dataset", default=None, help="Dataset name (e.g., 'opto_benz'). If omitted, will try to infer.")
+    ap.add_argument("--trial-type", default="testing", help="Trial type name (default: 'testing').")
+    ap.add_argument("--fly-name", default=None, help="Override fly name to match code_maps['fly'] keys (e.g., 'september_24_fly_1').")
+    ap.add_argument("--trial-label", default=None, help="Override trial label (e.g., 'testing_3').")
     args = ap.parse_args()
 
     # Find videos
@@ -192,38 +195,127 @@ def main():
         print("No videos found.")
         sys.exit(1)
 
-    # Map base name -> CSV path
-    data_map = {}
-    if args.data:
-        for root,_,files in os.walk(args.data):
-            for f in files:
-                fname_lower = f.lower()
-                if fname_lower.endswith(".csv") and 'testing' in fname_lower:
-                    data_map[os.path.splitext(f)[0]] = os.path.join(root,f)
+    # ----- Load matrix + code maps -----
+    mat = np.load(args.matrix, mmap_mode="r")
+    with open(args.codes, "r") as f:
+        maps_obj = json.load(f)
+    COLS = maps_obj.get("column_order", [])
+    CODE = maps_obj.get("code_maps", {})
 
-    def csv_for(video_path):
-        base = os.path.splitext(os.path.basename(video_path))[0]
-        if 'testing' not in base.lower():
-            return None
-        if base in data_map:
-            return data_map[base]
-        candidate = os.path.join(os.path.dirname(video_path), base + ".csv")
-        return candidate if os.path.exists(candidate) else None
+    def invert(d):
+        return {v: k for k, v in d.items()}
+
+    R = {
+        "dataset": invert(CODE.get("dataset", {})),
+        "fly":     invert(CODE.get("fly", {})),
+        "trial_type": invert(CODE.get("trial_type", {})),
+        "trial_label": invert(CODE.get("trial_label", {})),
+        "fps":     invert(CODE.get("fps", {})),
+    }
+
+    IDX = {name: idx for idx, name in enumerate(COLS)}
+    try:
+        first_dir_idx = next(i for i, name in enumerate(COLS) if name.startswith("dir_val_"))
+    except StopIteration:
+        raise ValueError("Matrix is missing directional envelope columns (dir_val_*).")
+
+    # -------- Helpers to parse video → metadata keys in code_maps --------
+    def _infer_trial_label_from_name(name):
+        # Look for patterns like testing_3, testing_09, etc.
+        m = re.search(r'(testing(?:_|-)?\d+)', name, flags=re.IGNORECASE)
+        return m.group(1).lower().replace('-', '_') if m else None
+
+    def _infer_fly_from_path(video_path):
+        # Prefer parent directory if it looks like '*_fly_*'
+        parent = os.path.basename(os.path.dirname(video_path))
+        if "_fly_" in parent.lower():
+            return parent
+        # Fallback to any dir segment that matches keys in code_maps['fly']
+        parts = [p for p in os.path.normpath(video_path).split(os.sep) if p]
+        fly_keys = set(CODE.get("fly", {}).keys())
+        for p in reversed(parts):
+            if p in fly_keys:
+                return p
+        # Fallback to digits → choose any fly name that endswith '_fly_<digits>'
+        digits = ''.join(filter(str.isdigit, os.path.splitext(os.path.basename(video_path))[0]))
+        if digits:
+            suffix = f"_fly_{digits}"
+            candidates = [k for k in fly_keys if k.endswith(suffix)]
+            if len(candidates) == 1:
+                return candidates[0]
+        return None
+
+    def encode(meta_name, meta_value):
+        # Map string value to code integer stored in matrix (as float16)
+        cmap = CODE.get(meta_name, {})
+        if meta_value in cmap:
+            return float(cmap[meta_value])
+        return float(0)
+
+    def decode_fps_code(code_float16):
+        # fps map in JSON uses strings; invert() produced string keys (e.g., "1":"40.0")
+        try:
+            key = int(round(float(code_float16)))
+        except Exception:
+            key = 0
+        str_val = R["fps"].get(key, "0")
+        try:
+            return float(str_val)
+        except Exception:
+            return 0.0
+
+    def find_matrix_row(video_path):
+        # Determine metadata strings
+        fly_name = args.fly_name or _infer_fly_from_path(video_path)
+        base_name = os.path.basename(video_path)
+        trial_label = (
+            args.trial_label
+            or _infer_trial_label_from_name(base_name)
+            or _infer_trial_label_from_name(os.path.splitext(base_name)[0])
+        )
+        dataset_candidates = [k for k in CODE.get("dataset", {}) if k != "UNKNOWN"]
+        dataset = args.dataset or (dataset_candidates[0] if dataset_candidates else "UNKNOWN")
+        trial_type = args.trial_type or "testing"
+
+        # Encode to codes
+        want = {
+            "dataset": encode("dataset", dataset),
+            "fly": encode("fly", fly_name) if fly_name else float(0),
+            "trial_type": encode("trial_type", trial_type),
+            "trial_label": encode("trial_label", trial_label) if trial_label else float(0),
+        }
+
+        col_d = IDX.get("dataset")
+        col_f = IDX.get("fly")
+        col_tt = IDX.get("trial_type")
+        col_tl = IDX.get("trial_label")
+
+        rows = []
+        for r in range(mat.shape[0]):
+            ok = True
+            if col_d is not None and want["dataset"] != 0 and mat[r, col_d] != want["dataset"]:
+                ok = False
+            if col_f is not None and want["fly"] != 0 and mat[r, col_f] != want["fly"]:
+                ok = False
+            if col_tt is not None and want["trial_type"] != 0 and mat[r, col_tt] != want["trial_type"]:
+                ok = False
+            if col_tl is not None and want["trial_label"] != 0 and mat[r, col_tl] != want["trial_label"]:
+                ok = False
+            if ok:
+                rows.append(r)
+        return rows[0] if rows else None
 
     # Precompute metrics + global max AUC for scaling
     items = []
     global_max_auc = {key: 0.0 for key in SEGMENTS}
+    legacy_csv_cache = {}
     for vp in videos:
-        cp = csv_for(vp)
-        if cp is None or not os.path.exists(cp):
-            print(f"[WARN] No CSV for {vp}, skipping.")
-            continue
-        try:
-            df = pd.read_csv(cp)
-        except Exception as e:
-            print(f"[WARN] Failed reading {cp}: {e}")
-            continue
-
+        row_idx = find_matrix_row(vp)
+        if row_idx is None:
+            # Optional fallback: try CSV if user passed --data
+            if not args.data:
+                print(f"[WARN] No matrix row for {vp}; skipping. (Provide --fly-name/--trial-label if needed.)")
+                continue
         cap = cv2.VideoCapture(vp)
         if not cap.isOpened():
             print(f"[WARN] Cannot open video {vp}, skipping.")
@@ -235,12 +327,53 @@ def main():
         frame_count = int(frame_count_val) if frame_count_val and frame_count_val > 0 else None
         cap.release()
 
-        sig_raw = choose_signal_column(df)
-        sig_series = pd.to_numeric(pd.Series(sig_raw), errors='coerce').fillna(0.0).to_numpy(dtype=float)
-        fps_for_calc = fps if fps and fps > 0 else 30.0
-        time_axis = extract_time_seconds(df, fps_for_calc)
-        envelope = compute_envelope(sig_series, fps_for_calc)
-        threshold = compute_threshold(time_axis, envelope, fps_for_calc)
+        if row_idx is not None:
+            row = mat[row_idx, :]
+            fps_col = IDX.get("fps")
+            fps_code = row[fps_col] if fps_col is not None else 0
+            fps_from_matrix = decode_fps_code(fps_code)
+            fps_for_calc = fps_from_matrix if fps_from_matrix > 0 else (fps if fps > 0 else DEFAULT_SMOOTHING_FPS)
+            envelope = row[first_dir_idx:].astype(np.float32)
+            if envelope.size and envelope[-1] == 0.0:
+                nz = np.nonzero(envelope)[0]
+                if nz.size:
+                    envelope = envelope[: (nz[-1] + 1)]
+            time_axis = (
+                np.arange(len(envelope), dtype=float) / float(fps_for_calc)
+                if fps_for_calc > 0
+                else np.arange(len(envelope), dtype=float)
+            )
+            threshold = compute_threshold(time_axis, envelope, fps_for_calc)
+            source_csv = None
+        else:
+            base = os.path.splitext(os.path.basename(vp))[0]
+            candidate = os.path.join(os.path.dirname(vp), base + ".csv")
+            cp = candidate if os.path.exists(candidate) else None
+            if not cp and args.data:
+                if base in legacy_csv_cache:
+                    cp = legacy_csv_cache[base]
+                else:
+                    found = None
+                    for root, _, files in os.walk(args.data):
+                        for f in files:
+                            if f.lower().endswith('.csv') and os.path.splitext(f)[0] == base:
+                                found = os.path.join(root, f)
+                                break
+                        if found:
+                            break
+                    legacy_csv_cache[base] = found
+                    cp = found
+            if not cp:
+                print(f"[WARN] No matrix row and no CSV for {vp}; skipping.")
+                continue
+            df = pd.read_csv(cp)
+            sig_raw = choose_signal_column(df)
+            sig_series = pd.to_numeric(pd.Series(sig_raw), errors='coerce').fillna(0.0).to_numpy(dtype=float)
+            fps_for_calc = fps if fps and fps > 0 else DEFAULT_SMOOTHING_FPS
+            time_axis = extract_time_seconds(df, fps_for_calc)
+            envelope = compute_envelope(sig_series, fps_for_calc)
+            threshold = compute_threshold(time_axis, envelope, fps_for_calc)
+            source_csv = cp
 
         segment_metrics = {}
         signal_limit_frames = len(envelope)
@@ -278,7 +411,8 @@ def main():
 
         item = {
             'video_path': vp,
-            'csv_path': cp,
+            'csv_path': source_csv,
+            'matrix_row_index': row_idx if row_idx is not None else -1,
             'fly_id': None,
             'trial_id': None,
             'segments': segment_metrics,
@@ -471,7 +605,8 @@ def main():
             "fly_id": fly_id,
             "trial_id": trial_id,
             "video_file": os.path.basename(it['video_path']),
-            "csv_file": os.path.basename(it['csv_path']),
+            "csv_file": os.path.basename(it['csv_path']) if it['csv_path'] else "",
+            "matrix_row_index": it.get("matrix_row_index", -1),
             "display_duration_seconds": it['display_duration']
         }
         row["threshold"] = threshold_value


### PR DESCRIPTION
## Summary
- require matrix and codes inputs for the labeling UI and expose metadata override flags
- load precomputed envelopes from the provided matrix, inferring matching rows or falling back to legacy CSVs
- record the matched matrix row in the exported results while keeping legacy CSV tracking optional

## Testing
- python -m compileall label_videos.py

------
https://chatgpt.com/codex/tasks/task_e_68dade039db4832da79b58dadfbf4a65