### PR TITLE
Add GUI exit option and reuse stored annotations

### DIFF
--- a/fly_behavior/metrics.py
+++ b/fly_behavior/metrics.py
@@ -24,7 +24,19 @@ def compute_metrics(signal: np.ndarray, fps: float, threshold: float) -> dict | 
 
     if above.any():
         auc = float(np.sum(signal[above] - thresh)) / (fps_val if fps_val > 0 else 1.0)
+        first_cross_idx = int(np.flatnonzero(above)[0])
+        time_to_threshold = (
+            first_cross_idx / fps_val if fps_val > 0 else float(first_cross_idx)
+        )
     else:
         auc = 0.0
+        first_cross_idx = None
+        time_to_threshold = None
 
-    return {'time_fraction': time_fraction, 'auc': auc, 'duration': duration}
+    return {
+        'time_fraction': time_fraction,
+        'auc': auc,
+        'duration': duration,
+        'crossed_threshold': bool(first_cross_idx is not None),
+        'time_to_threshold': time_to_threshold,
+    }


### PR DESCRIPTION
## Summary
- load existing scoring rows so previously annotated videos can be reused instead of rescored
- add a save-and-exit control that writes current progress and closes the labeling GUI safely
- persist combined existing and new annotations back to the output CSV when finishing or exiting

## Testing
- python -m compileall label_videos.py fly_behavior

------
https://chatgpt.com/codex/tasks/task_e_68dc18d08b70832dad14fee89bc4e470