### PR TITLE
Switch GUI scoring to five-point scale and add rise metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Fly Behavior Scoring & ML Starter
 
 A ready-to-run, Git-ready project to:
-- Label fly behavior videos with a 0–10 human score via a simple GUI.
-- Compute data-driven metrics (e.g., time above threshold, AUC) and a data score.
+- Label fly behavior videos with a 0–5 human score via a simple GUI.
+- Compute data-driven metrics (e.g., time above threshold, AUC, reaction latency, rise speed) and a data score.
 - Persist meticulous, per-trial metadata to a single master CSV.
-- Train a baseline PyTorch regressor to predict scores from metrics (outputs 0–10 after rounding).
+- Train a baseline PyTorch regressor to predict scores from metrics (outputs 0–5 after rounding).
 
 ## Quick start
 
@@ -19,7 +19,7 @@ pip install -r requirements.txt
 python label_videos.py   --videos /path/to/videos   --data   /path/to/csvs   --output scoring_results.csv
 ```
 
-- The GUI shows **video first** with a 0–10 selector (0=NR, 5=Average, 10=Strongest).
+- The GUI shows **video first** with a 0–5 selector.
 - After you submit, it reveals metrics and **data-derived score** (weights configurable).
 - All rows are appended to a single **master CSV** with fly/trial/video/user score/data score/combined score and raw metrics.
 
@@ -29,7 +29,7 @@ python label_videos.py   --videos /path/to/videos   --data   /path/to/csvs   --o
 python train_model.py --data scoring_results.csv --epochs 100 --output-model fly_score_model.pth
 ```
 
-- Predicts a continuous score that you should **round to 0–10** for reporting.
+- Predicts a continuous score that you should **round to 0–5** for reporting.
 - GPU is used automatically when available (PyTorch + CUDA).
 
 ## Configure metric weights / threshold

--- a/fly_behavior/metrics.py
+++ b/fly_behavior/metrics.py
@@ -24,7 +24,58 @@ def compute_metrics(signal: np.ndarray, fps: float, threshold: float) -> dict | 
 
     if above.any():
         auc = float(np.sum(signal[above] - thresh)) / (fps_val if fps_val > 0 else 1.0)
+        first_cross_idx = int(np.flatnonzero(above)[0])
+        time_to_threshold = (
+            first_cross_idx / fps_val if fps_val > 0 else float(first_cross_idx)
+        )
     else:
         auc = 0.0
+        first_cross_idx = None
+        time_to_threshold = None
 
-    return {'time_fraction': time_fraction, 'auc': auc, 'duration': duration}
+    peak_value = None
+    time_to_peak = None
+    rise_speed = None
+    rise_acceleration = None
+
+    if first_cross_idx is not None:
+        post_cross = signal[first_cross_idx:]
+        if post_cross.size:
+            rel_peak_idx = int(np.argmax(post_cross))
+            peak_idx = first_cross_idx + rel_peak_idx
+            peak_value = float(signal[peak_idx])
+            if fps_val > 0:
+                time_to_peak = (peak_idx - first_cross_idx) / fps_val
+            else:
+                time_to_peak = float(peak_idx - first_cross_idx)
+
+            if time_to_peak and time_to_peak > 0:
+                value_at_cross = float(signal[first_cross_idx])
+                rise_amplitude = max(0.0, peak_value - value_at_cross)
+                rise_speed = rise_amplitude / time_to_peak
+
+                if peak_idx > first_cross_idx and fps_val > 0:
+                    window = signal[first_cross_idx : peak_idx + 1]
+                    if window.size >= 2:
+                        velocities = np.gradient(window, 1.0 / fps_val)
+                        rise_acceleration = (velocities[-1] - velocities[0]) / time_to_peak
+                    else:
+                        rise_acceleration = 0.0
+                else:
+                    rise_acceleration = 0.0
+            else:
+                time_to_peak = 0.0
+                rise_speed = 0.0
+                rise_acceleration = 0.0
+
+    return {
+        'time_fraction': time_fraction,
+        'auc': auc,
+        'duration': duration,
+        'crossed_threshold': bool(first_cross_idx is not None),
+        'time_to_threshold': time_to_threshold,
+        'time_to_peak': time_to_peak,
+        'peak_value': peak_value,
+        'rise_speed': rise_speed,
+        'rise_acceleration': rise_acceleration,
+    }

--- a/label_videos.py
+++ b/label_videos.py
@@ -23,9 +23,10 @@ from fly_behavior import (
 
 # =================== CONFIG (edit as needed) ===================
 METRIC_WEIGHTS = {
-    # Increase/decrease to change influence on data_score (0–10 scale per metric)
+    # Increase/decrease to change influence on data_score (0–5 scale per metric)
     'time_fraction': 1.0,   # fraction of frames above threshold
-    'auc': 1.0              # integral above threshold (scaled by global max)
+    'auc': 1.0,             # integral above threshold (scaled by global max)
+    'time_to_threshold': 1.0  # rapid responses score higher (lower time is better)
 }
 # ===============================================================
 
@@ -33,7 +34,7 @@ METRIC_WEIGHTS = {
 TARGET_W, TARGET_H = 640, 640  # You can adjust these values
 
 def main():
-    ap = argparse.ArgumentParser(description="Label fly behavior videos (0–10) and compute data-driven scores.")
+    ap = argparse.ArgumentParser(description="Label fly behavior videos (0–5) and compute data-driven scores.")
     ap.add_argument("-v","--videos", required=True, help="Folder with videos (recursively scanned).")
     # Legacy CSV input is now optional/unused; kept for backward compatibility.
     ap.add_argument("-d","--data", default=None, help="(Deprecated) Folder with CSV traces. If provided and matrix row not found, will fallback.")
@@ -185,7 +186,6 @@ def main():
     # Precompute metrics + global max AUC for scaling
     items = []
     global_max_auc = {seg.key: 0.0 for seg in segment_defs}
-    global_max_auc = {key: 0.0 for key in SEGMENTS}
     legacy_csv_cache = {}
     for vp in videos:
         row_idx = find_matrix_row(vp)
@@ -222,7 +222,6 @@ def main():
                 else np.arange(len(envelope), dtype=float)
             )
             threshold = compute_threshold(time_axis, envelope, fps_for_calc, BASELINE_SECONDS)
-            threshold = compute_threshold(time_axis, envelope, fps_for_calc)
             source_csv = None
         else:
             base = os.path.splitext(os.path.basename(vp))[0]
@@ -252,7 +251,6 @@ def main():
             time_axis = extract_time_seconds(df, fps_for_calc)
             envelope = compute_envelope(sig_series, fps_for_calc)
             threshold = compute_threshold(time_axis, envelope, fps_for_calc, BASELINE_SECONDS)
-            threshold = compute_threshold(time_axis, envelope, fps_for_calc)
             source_csv = cp
 
         segment_metrics = {}
@@ -287,32 +285,69 @@ def main():
             print(f"[WARN] No playable frames for {vp}, skipping.")
             continue
 
-        item = {'video_path': vp, 'csv_path': source_csv, 'matrix_row_index': row_idx if row_idx is not None else -1,
-                'fly_id': (parse_fly_trial(vp))[0], 'trial_id': (parse_fly_trial(vp))[1], 'segments': segment_metrics,
-                'threshold': threshold, 'fps': fps_for_calc, 'max_frames': max_frames, 'display_duration': min(
-                analysis_seconds,
-                max_frames / fps_for_calc if fps_for_calc > 0 else analysis_seconds,
-            ), 'segment_windows': segment_windows, 'odor_latency_seconds': odor_latency_seconds}
-
-
+        fly_id, trial_id = parse_fly_trial(vp)
         item = {
             'video_path': vp,
+            'video_file': os.path.basename(vp),
             'csv_path': source_csv,
             'matrix_row_index': row_idx if row_idx is not None else -1,
-            'fly_id': None,
-            'trial_id': None,
+            'fly_id': fly_id,
+            'trial_id': trial_id,
             'segments': segment_metrics,
             'threshold': threshold,
             'fps': fps_for_calc,
             'max_frames': max_frames,
-            'display_duration': min(TOTAL_DISPLAY_SECONDS, max_frames / fps_for_calc if fps_for_calc > 0 else TOTAL_DISPLAY_SECONDS)
+            'display_duration': min(
+                analysis_seconds,
+                max_frames / fps_for_calc if fps_for_calc > 0 else analysis_seconds,
+            ),
+            'segment_windows': segment_windows,
+            'odor_latency_seconds': odor_latency_seconds,
         }
-        item['fly_id'], item['trial_id'] = parse_fly_trial(vp)
         items.append(item)
 
     if not items:
         print("Nothing to score (no metric-bearing pairs).")
         sys.exit(1)
+
+    # Load any prior annotations so we can optionally reuse them
+    existing_rows = []
+    existing_by_video = {}
+    if os.path.exists(args.output):
+        try:
+            prior_df = pd.read_csv(args.output)
+            existing_rows = prior_df.to_dict("records")
+            for row in existing_rows:
+                video_file = row.get("video_file")
+                if isinstance(video_file, str) and video_file:
+                    existing_by_video.setdefault(video_file, []).append(row)
+        except Exception as exc:
+            print(f"[WARN] Failed to load existing output CSV '{args.output}': {exc}")
+            existing_rows = []
+            existing_by_video = {}
+
+    processed_videos = set()
+    completed_rows = []
+
+    def gather_output_rows():
+        remaining = [
+            row for row in existing_rows if row.get("video_file") not in processed_videos
+        ]
+        return remaining + completed_rows
+
+    def finalize_and_close(message=None, show_dialog=True):
+        nonlocal cap
+        out_rows = gather_output_rows()
+        if out_rows:
+            pd.DataFrame(out_rows).to_csv(args.output, index=False)
+        else:
+            pd.DataFrame([]).to_csv(args.output, index=False)
+        if cap:
+            cap.release()
+        cap = None
+        if show_dialog and message:
+            messagebox.showinfo("Progress Saved", message)
+        root.destroy()
 
     # ---------- GUI ----------
     root = tk.Tk()
@@ -343,7 +378,7 @@ def main():
         f"(30 s baseline + {odor_latency_seconds:.1f} s latency + "
         f"{int(SEGMENT_MAP['odor'].duration_seconds)} s odor + "
         f"{int(SEGMENT_MAP['post'].duration_seconds)} s post-odor).\n"
-        "Provide a rating for each rateable interval using the scale below, then submit to reveal the data metrics."
+        "Provide a rating for each rateable interval using the 0–5 scale below, then submit to reveal the data metrics."
     )
     info = ttk.Label(root, text=info_text, style="Likert.TLabel", wraplength=TARGET_W, justify="left")
     info.pack(pady=(6, 4), padx=8, anchor="w")
@@ -368,7 +403,7 @@ def main():
         var = tk.IntVar(value=-1)
         score_vars[seg.key] = var
 
-        for idx, val in enumerate(range(0, 11)):
+        for idx, val in enumerate(range(0, 6)):
             cell = ttk.Frame(scale_inner, padding=1, style="Likert.TFrame")
             cell.grid(row=0, column=idx, padx=2)
             btn = ttk.Radiobutton(cell, variable=var, value=val, style="Likert.TRadiobutton", takefocus=0)
@@ -380,52 +415,17 @@ def main():
     rating_frame.pack(pady=4, fill="x")
     for seg in rateable_segments:
         build_likert_scale(rating_frame, seg)
-
-    canvas = tk.Canvas(root, width=max_w, height=max_h, bg="black", highlightthickness=0)
-    canvas.pack()
-
-    info = ttk.Label(root, text="Watch the first 90 seconds. Provide a rating for each interval using the scale below, then submit to reveal the data metrics.", style="Likert.TLabel", wraplength=max_w)
-    info.pack(pady=(10, 6), padx=16, anchor="w")
-
-    score_vars = {}
-
-    def build_likert_scale(parent, seg_key, seg_cfg):
-        container = ttk.Frame(parent, padding=(12, 10), style="Likert.TFrame")
-        container.pack(fill="x", pady=4)
-        ttk.Label(container, text=seg_cfg['label'], font=("Helvetica", 13, "bold"), style="Likert.TLabel").pack(anchor="w")
-
-        descriptors = ttk.Frame(container, style="Likert.TFrame")
-        descriptors.pack(fill="x", pady=(8, 4))
-        ttk.Label(descriptors, text="No Reaction", style="Likert.TLabel").pack(side="left")
-        ttk.Label(descriptors, text="Strong Reaction", style="Likert.TLabel").pack(side="right")
-
-        scale_inner = ttk.Frame(container, style="Likert.TFrame")
-        scale_inner.pack()
-
-        var = tk.IntVar(value=-1)
-        score_vars[seg_key] = var
-
-        for idx, val in enumerate(range(0, 11)):
-            cell = ttk.Frame(scale_inner, padding=2, style="Likert.TFrame")
-            cell.grid(row=0, column=idx, padx=6)
-            btn = ttk.Radiobutton(cell, variable=var, value=val, style="Likert.TRadiobutton", takefocus=0)
-            btn.pack()
-            ttk.Label(cell, text=str(val), style="Likert.TLabel").pack(pady=(4, 0))
-
-    # Rating row
-    rating_frame = ttk.Frame(root, padding=(8, 4), style="Likert.TFrame")
-    rating_frame.pack(pady=4, fill="x")
-    for seg_key, seg_cfg in SEGMENTS.items():
-        build_likert_scale(rating_frame, seg_key, seg_cfg)
         
     # Buttons
     btns = ttk.Frame(root, padding=6, style="Likert.TFrame"); btns.pack(pady=8)
     submit_btn = ttk.Button(btns, text="Submit Score")
     next_btn   = ttk.Button(btns, text="Next Video", state=tk.DISABLED)
     replay_btn = ttk.Button(btns, text="Replay Video")
+    exit_btn   = ttk.Button(btns, text="Save && Exit")
     submit_btn.grid(row=0,column=0,padx=4)
     next_btn.grid(row=0,column=1,padx=4)
     replay_btn.grid(row=0,column=2,padx=4)
+    exit_btn.grid(row=0,column=3,padx=4)
 
     # Data panel (revealed post-submit)
     data_panel = ttk.Frame(root, padding=(12, 8), style="Likert.TFrame")
@@ -438,18 +438,45 @@ def main():
 
     # State
     idx = 0
-    results = []
     cap = None
     fps = 40.0
     playing = False
     frame_counter = 0
     current_max_frames = 0
 
-    def play(index):
+    def play_current():
         nonlocal cap, fps, playing, frame_counter, current_max_frames
-        if cap: cap.release()
-        item = items[index]
+        if cap:
+            cap.release()
+        item = items[idx]
         vp = item['video_path']
+        video_file = item['video_file']
+
+        if video_file in processed_videos:
+            advance_to_next_video()
+            return
+
+        prior_rows = existing_by_video.get(video_file)
+        if prior_rows:
+            reuse = messagebox.askyesno(
+                "Reuse prior annotation?",
+                (
+                    f"An entry for '{video_file}' already exists in {args.output}.\n"
+                    "Do you want to reuse the previous annotation instead of rescoring?"
+                ),
+            )
+            if reuse:
+                processed_videos.add(video_file)
+                completed_rows.append(dict(prior_rows[-1]))
+                messagebox.showinfo(
+                    "Annotation Reused",
+                    f"Using previously saved annotations for '{video_file}'.",
+                )
+                advance_to_next_video()
+                return
+
+        submit_btn.config(state=tk.NORMAL)
+        next_btn.config(state=tk.DISABLED)
         cap = cv2.VideoCapture(vp)
         if not cap.isOpened():
             messagebox.showerror("Error", f"Cannot open video: {vp}")
@@ -466,9 +493,9 @@ def main():
         data_text.delete("1.0", tk.END)
         data_text.configure(state="disabled")
         info.config(text=(
-            f"{os.path.basename(vp)}  [{index+1}/{len(items)}] — "
+            f"{os.path.basename(vp)}  [{idx+1}/{len(items)}] — "
             f"windows include 30 s baseline + 2x{odor_latency_seconds:.1f}s latency. "
-            f"Rate each active interval (0–10). Showing first {item['display_duration']:.1f}s."
+            f"Rate each active interval (0–5). Showing first {item['display_duration']:.1f}s."
         ))
         playing = True
         root.after(0, advance)
@@ -530,15 +557,28 @@ def main():
             duration = metrics['duration'] if metrics else 0.0
             time_fraction = metrics['time_fraction'] if metrics else 0.0
             auc_val = metrics['auc'] if metrics else 0.0
+            time_to_threshold = metrics.get('time_to_threshold') if metrics else None
+            crossed_threshold = metrics.get('crossed_threshold', False) if metrics else False
+            time_to_peak = metrics.get('time_to_peak') if metrics else None
+            peak_value = metrics.get('peak_value') if metrics else None
+            rise_speed = metrics.get('rise_speed') if metrics else None
+            rise_acceleration = metrics.get('rise_acceleration') if metrics else None
 
-            # Scale metrics to 0–10
+            # Scale metrics to 0–5
             if metrics:
                 m_parts = {
-                    'time_fraction': max(0.0, min(10.0, time_fraction * 10.0)),
-                    'auc': max(0.0, min(10.0, (auc_val / global_max_auc[seg.key] * 10.0) if global_max_auc[seg.key] > 0 else 0.0))
+                    'time_fraction': max(0.0, min(5.0, time_fraction * 5.0)),
+                    'auc': max(0.0, min(5.0, (auc_val / global_max_auc[seg.key] * 5.0) if global_max_auc[seg.key] > 0 else 0.0)),
                 }
+                if 'time_to_threshold' in METRIC_WEIGHTS:
+                    if duration > 0 and time_to_threshold is not None:
+                        clamped_time = max(0.0, min(time_to_threshold, duration))
+                        response_score = 5.0 * (1.0 - (clamped_time / duration))
+                    else:
+                        response_score = 0.0
+                    m_parts['time_to_threshold'] = max(0.0, min(5.0, response_score))
             else:
-                m_parts = {'time_fraction': 0.0, 'auc': 0.0}
+                m_parts = {k: 0.0 for k in METRIC_WEIGHTS}
 
             wsum = 0.0
             score_sum = 0.0
@@ -565,8 +605,20 @@ def main():
                     f"{label}:",
                     f"  Time above threshold: {time_above:.2f}s ({pct:.1f}%)",
                     f"  AUC over threshold: {auc_val:.3f}",
-                    f"  Data-suggested score: {data_score}",
                 ]
+                if time_to_threshold is not None:
+                    entry_lines.append(f"  Time to threshold: {time_to_threshold:.2f}s")
+                else:
+                    entry_lines.append("  Time to threshold: not reached")
+                if time_to_peak is not None:
+                    entry_lines.append(f"  Time to peak: {time_to_peak:.2f}s")
+                if peak_value is not None:
+                    entry_lines.append(f"  Peak value: {peak_value:.3f}")
+                if rise_speed is not None:
+                    entry_lines.append(f"  Rise speed: {rise_speed:.3f}/s")
+                if rise_acceleration is not None:
+                    entry_lines.append(f"  Rise acceleration: {rise_acceleration:.3f}/s²")
+                entry_lines.append(f"  Data-suggested score: {data_score}")
                 if seg.rateable:
                     entry_lines.append(f"  Your score: {user_score}")
                     entry_lines.append(f"  Combined score: {combined:.1f}")
@@ -582,13 +634,14 @@ def main():
                 'time_fraction': time_fraction,
                 'auc': auc_val,
                 'duration': duration,
-                'time_above_threshold': time_above
+                'time_above_threshold': time_above,
+                'time_to_threshold': time_to_threshold,
+                'crossed_threshold': crossed_threshold,
+                'time_to_peak': time_to_peak,
+                'peak_value': peak_value,
+                'rise_speed': rise_speed,
+                'rise_acceleration': rise_acceleration,
             }
-
-        row = {"fly_id": fly_id, "trial_id": trial_id, "video_file": os.path.basename(it['video_path']),
-               "csv_file": os.path.basename(it['csv_path']) if it['csv_path'] else "",
-               "matrix_row_index": it.get("matrix_row_index", -1), "display_duration_seconds": it['display_duration'],
-               "odor_latency_seconds": latency_value, "threshold": threshold_value}
 
         row = {
             "fly_id": fly_id,
@@ -596,11 +649,12 @@ def main():
             "video_file": os.path.basename(it['video_path']),
             "csv_file": os.path.basename(it['csv_path']) if it['csv_path'] else "",
             "matrix_row_index": it.get("matrix_row_index", -1),
-            "display_duration_seconds": it['display_duration']
+            "display_duration_seconds": it['display_duration'],
+            "odor_latency_seconds": latency_value,
+            "threshold": threshold_value,
         }
-        row["threshold"] = threshold_value
 
-    for seg_key, seg_res in segment_results.items():
+        for seg_key, seg_res in segment_results.items():
             user_entry = seg_res['user_score'] if seg_res['user_score'] is not None else None
             row[f"user_score_{seg_key}"] = user_entry
             row[f"data_score_{seg_key}"] = seg_res['data_score']
@@ -609,8 +663,15 @@ def main():
             row[f"auc_{seg_key}"] = seg_res['auc']
             row[f"time_above_threshold_{seg_key}"] = seg_res['time_above_threshold']
             row[f"segment_duration_{seg_key}"] = seg_res['duration']
+            row[f"time_to_threshold_{seg_key}"] = seg_res.get('time_to_threshold')
+            row[f"crossed_threshold_{seg_key}"] = seg_res.get('crossed_threshold')
+            row[f"time_to_peak_{seg_key}"] = seg_res.get('time_to_peak')
+            row[f"peak_value_{seg_key}"] = seg_res.get('peak_value')
+            row[f"rise_speed_{seg_key}"] = seg_res.get('rise_speed')
+            row[f"rise_acceleration_{seg_key}"] = seg_res.get('rise_acceleration')
 
-        results.append(row)
+        completed_rows.append(row)
+        processed_videos.add(row['video_file'])
 
         data_text.configure(state="normal")
         data_text.delete("1.0", tk.END)
@@ -621,26 +682,44 @@ def main():
         submit_btn.config(state=tk.DISABLED)
         next_btn.config(state=tk.NORMAL)
 
-    def on_next():
-        nonlocal idx, cap
+    def advance_to_next_video():
+        nonlocal idx, cap, playing
+        playing = False
+        if cap:
+            cap.release()
+            cap = None
         idx += 1
         if idx >= len(items):
-            out = args.output
-            pd.DataFrame(results).to_csv(out, index=False)
-            if cap:
-                cap.release()
-            messagebox.showinfo("Done", f"All videos scored.\nSaved: {out}")
-            root.destroy()
+            finalize_and_close(
+                message=f"All videos scored.\nSaved: {args.output}",
+                show_dialog=True,
+            )
             return
-        next_btn.config(state=tk.DISABLED)
         submit_btn.config(state=tk.NORMAL)
-        play(idx)
+        next_btn.config(state=tk.DISABLED)
+        play_current()
+
+    def on_next():
+        advance_to_next_video()
+
+    def on_exit():
+        if messagebox.askyesno(
+            "Save and Exit",
+            "Save current progress to the output CSV and exit the scorer?",
+        ):
+            finalize_and_close(
+                message=f"Progress saved to {args.output}.",
+                show_dialog=True,
+            )
 
     submit_btn.config(command=on_submit)
     next_btn.config(command=on_next)
     replay_btn.config(command=on_replay)
+    exit_btn.config(command=on_exit)
 
-    play(idx)
+    root.protocol("WM_DELETE_WINDOW", on_exit)
+
+    play_current()
     root.mainloop()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- switch the labeling workflow, README, and scoring text to a five-point human/data scale
- compute and surface reaction rise metrics including time-to-peak, peak magnitude, rise speed, and rise acceleration
- write the new metrics into the CSV export alongside existing threshold-crossing data

## Testing
- python -m compileall fly_behavior label_videos.py

------
https://chatgpt.com/codex/tasks/task_e_68dc18d08b70832dad14fee89bc4e470