### PR TITLE
Refine odor reaction features to exclude baseline stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.vscode/
+.venv/
+outputs/
+# Runtime data inputs
+*.npy
+*.npz
+code_maps.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ opencv-python
 Pillow
 torch
 scikit-learn
+matplotlib
+hdbscan

--- a/unsup/__init__.py
+++ b/unsup/__init__.py
@@ -1,0 +1,5 @@
+"""Unsupervised clustering utilities for FlyBehaviorScoring."""
+
+from . import data_prep, metrics, models, pca_core, plots  # noqa: F401
+
+__all__ = ["data_prep", "metrics", "models", "pca_core", "plots"]

--- a/unsup/data_prep.py
+++ b/unsup/data_prep.py
@@ -1,0 +1,369 @@
+"""Data loading and preprocessing utilities for unsupervised clustering."""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+TIME_COLUMN_PATTERN = re.compile(r"dir[\W_]*val[\W_]*(\d+)", re.IGNORECASE)
+MAX_TIME_COLUMNS = 3600
+
+
+@dataclass
+class PreparedData:
+    """Container for standardized traces and associated metadata."""
+
+    traces: np.ndarray
+    metadata: pd.DataFrame
+    time_columns: List[str]
+
+    @property
+    def n_trials(self) -> int:
+        return self.traces.shape[0]
+
+    @property
+    def n_timepoints(self) -> int:
+        return self.traces.shape[1]
+
+
+def _load_inputs(npy_path: Path, meta_path: Path) -> Tuple[np.ndarray, dict]:
+    if not npy_path.exists():
+        raise FileNotFoundError(f"Missing npy file: {npy_path}")
+    if not meta_path.exists():
+        raise FileNotFoundError(f"Missing metadata file: {meta_path}")
+
+    data = np.load(npy_path)
+    with meta_path.open("r", encoding="utf-8") as fh:
+        meta = json.load(fh)
+    return data, meta
+
+
+def _to_python_scalar(value: object) -> object:
+    """Convert NumPy scalar types to native Python scalars."""
+
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
+def _normalize_mapping(mapping: object) -> dict:
+    """Return a dictionary with Python-native keys for mapping operations."""
+
+    if isinstance(mapping, dict):
+        items: Iterable[tuple] = mapping.items()
+    elif isinstance(mapping, Iterable) and not isinstance(mapping, (str, bytes)):
+        items = mapping  # type: ignore[assignment]
+    else:
+        raise TypeError("code_maps entries must be dicts or iterable pairs")
+
+    normalized: dict = {}
+    for key, value in items:  # type: ignore[misc]
+        normalized[_to_python_scalar(key)] = value
+    return normalized
+
+
+def _decode_categorical_columns(df: pd.DataFrame, code_maps: dict) -> pd.DataFrame:
+    for column, raw_mapping in code_maps.items():
+        if column not in df.columns:
+            continue
+
+        mapping = _normalize_mapping(raw_mapping)
+
+        # Some metadata files store mappings in label -> code form instead of
+        # code -> label. Detect this by checking whether any observed column
+        # values appear as mapping keys; if not, but they do appear among the
+        # mapping values, invert the dictionary so numeric codes map onto their
+        # human-readable labels.
+        column_values = {
+            _to_python_scalar(value) for value in df[column].dropna().unique()
+        }
+        mapping_keys = set(mapping.keys())
+        if column_values and not (column_values & mapping_keys):
+            mapping_values = {
+                _to_python_scalar(value) for value in mapping.values()
+            }
+            if column_values & mapping_values:
+                inverted: dict = {}
+                for key, value in mapping.items():
+                    inverted[_to_python_scalar(value)] = key
+                mapping = inverted
+
+        df[column] = df[column].apply(
+            lambda raw: mapping.get(_to_python_scalar(raw), raw)
+        )
+    return df
+
+
+def _normalize_column_key(name: str) -> str:
+    """Return a simplified key for fuzzy column matching."""
+
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
+def _stringify(value: object) -> str:
+    if pd.isna(value):  # type: ignore[arg-type]
+        return ""
+    return str(_to_python_scalar(value))
+
+
+def _extract_string_series(
+    df: pd.DataFrame,
+    candidate_names: Sequence[str],
+    *,
+    default_value: str = "",
+) -> Tuple[pd.Series, str | None]:
+    """Return the first matching column converted to strings."""
+
+    matched_name: str | None = None
+    for candidate in candidate_names:
+        candidate_key = _normalize_column_key(candidate)
+        for column in df.columns:
+            if _normalize_column_key(column) == candidate_key:
+                matched_name = column
+                break
+        if matched_name is not None:
+            break
+
+    if matched_name is None:
+        return pd.Series(default_value, index=df.index, dtype=str), None
+
+    series = df[matched_name].apply(_stringify)
+    return series.astype(str), matched_name
+
+
+def _identify_time_columns(columns: Sequence[str]) -> List[str]:
+    extracted: List[Tuple[str, int]] = []
+    for column in columns:
+        match = TIME_COLUMN_PATTERN.search(column)
+        if match:
+            try:
+                index = int(match.group(1))
+            except ValueError:
+                # Skip columns where the captured group is not an integer.
+                continue
+            extracted.append((column, index))
+
+    extracted.sort(key=lambda pair: pair[1])
+    return [name for name, _ in extracted]
+
+
+def _canonicalize_dataset_name(name: str) -> str:
+    """Map dataset aliases onto canonical EB/3-octonol labels."""
+
+    # Collapse punctuation and underscores so variants like ``opto_EB`` or
+    # ``Manual 3 Octonol`` normalize to predictable tokens.
+    normalized = re.sub(r"[^a-z0-9]+", " ", str(name).lower()).strip()
+    if not normalized:
+        return str(name)
+
+    tokens = normalized.split()
+    joined = "".join(tokens)
+
+    if any(token.startswith("3") for token in tokens) and "oct" in normalized:
+        return "3-octonol"
+    if "3oct" in joined or "threeoct" in joined:
+        return "3-octonol"
+
+    if "eb" in tokens or joined in {"eb", "ethylbutyrate"}:
+        return "EB"
+    if "ethyl" in tokens and "butyrate" in tokens:
+        return "EB"
+
+    return str(name)
+
+
+def prepare_data(
+    npy_path: Path,
+    meta_path: Path,
+    *,
+    target_datasets: Sequence[str] | None = None,
+    debug: bool = False,
+) -> PreparedData:
+    """Load, filter, and z-score trials for clustering.
+
+    Parameters
+    ----------
+    npy_path: Path
+        Path to the trial matrix stored as a NumPy array.
+    meta_path: Path
+        Path to JSON metadata describing column order and categorical maps.
+    target_datasets: Sequence[str] | None, optional keyword-only
+        Dataset names to retain. Defaults to {"EB", "3-octonol"}.
+
+    Returns
+    -------
+    PreparedData
+        The standardized traces alongside metadata and ordered time columns.
+    """
+
+    matrix, meta = _load_inputs(npy_path, meta_path)
+
+    if debug:
+        print(
+            "[prepare_data] Loaded inputs:",
+            f"matrix_shape={matrix.shape}",
+            f"n_columns_meta={len(meta.get('column_order', []))}",
+        )
+
+    column_order: Sequence[str] = meta["column_order"]
+    code_maps: dict = meta.get("code_maps", {})
+
+    if matrix.shape[1] != len(column_order):
+        raise ValueError(
+            "Mismatch between matrix feature count and metadata column order"
+        )
+
+    df = pd.DataFrame(matrix, columns=column_order)
+    if debug:
+        preview_cols = ", ".join(column_order[:8])
+        print(f"[prepare_data] Constructed DataFrame with columns: {preview_cols}...")
+
+    df = _decode_categorical_columns(df, code_maps)
+
+    time_columns = _identify_time_columns(df.columns)
+    if not time_columns:
+        sample_columns = ", ".join(list(df.columns[:10]))
+        raise ValueError(
+            "No time-series columns found matching pattern similar to 'dir_val_#'. "
+            f"First columns: [{sample_columns}]"
+        )
+
+    if len(time_columns) > MAX_TIME_COLUMNS:
+        extra_time_columns = time_columns[MAX_TIME_COLUMNS:]
+        df = df.drop(columns=extra_time_columns)
+        time_columns = time_columns[:MAX_TIME_COLUMNS]
+        if debug:
+            print(
+                "[prepare_data] Truncating time-series columns to first",
+                MAX_TIME_COLUMNS,
+                "entries",
+            )
+
+    dataset_series_raw, dataset_column = _extract_string_series(
+        df,
+        (
+            "dataset_name",
+            "dataset",
+            "dataset_label",
+            "dataset_full",
+            "dataset_id",
+            "datasetname",
+        ),
+    )
+    dataset_series = dataset_series_raw.map(_canonicalize_dataset_name)
+    df["dataset_name"] = dataset_series
+
+    if debug:
+        raw_counts = dataset_series_raw.value_counts(dropna=False).to_dict()
+        canonical_counts = dataset_series.value_counts(dropna=False).to_dict()
+        print(
+            "[prepare_data] Dataset column detected:",
+            dataset_column or "<missing>",
+        )
+        print(
+            "[prepare_data] Dataset counts (raw -> canonical):",
+            raw_counts,
+            canonical_counts,
+        )
+
+    trial_type_series, trial_type_column = _extract_string_series(
+        df,
+        (
+            "trial_type_name",
+            "trial_type",
+            "trialtype",
+            "trial_type_label",
+            "trial_label",
+        ),
+    )
+    df["trial_type_name"] = trial_type_series
+
+    if debug:
+        trial_counts = trial_type_series.value_counts(dropna=False).to_dict()
+        print(
+            "[prepare_data] Trial type column detected:",
+            trial_type_column or "<missing>",
+        )
+        print("[prepare_data] Trial type counts:", trial_counts)
+
+    # Filter for testing trials and targeted datasets.
+    trial_type_lower = trial_type_series.str.strip().str.lower()
+    filters = trial_type_lower == "testing"
+    if target_datasets is None:
+        dataset_candidates = {"EB", "3-octonol"}
+    else:
+        dataset_candidates = {
+            _canonicalize_dataset_name(str(candidate)) for candidate in target_datasets
+        }
+    dataset_mask = dataset_series.isin(dataset_candidates)
+    combined_mask = filters & dataset_mask
+    filtered = df.loc[combined_mask].reset_index(drop=True)
+
+    if debug:
+        print(
+            "[prepare_data] Target datasets after canonicalization:",
+            sorted(dataset_candidates),
+        )
+        print(
+            "[prepare_data] Trials passing dataset filter:",
+            int(dataset_mask.sum()),
+            "/",
+            len(df),
+        )
+        print(
+            "[prepare_data] Trials passing combined filter:",
+            len(filtered),
+            "/",
+            len(df),
+        )
+        if not filtered.empty:
+            filtered_dataset_counts = (
+                filtered["dataset_name"].value_counts(dropna=False).to_dict()
+            )
+            filtered_trial_counts = (
+                filtered["trial_type_name"].value_counts(dropna=False).to_dict()
+            )
+            print(
+                "[prepare_data] Filtered dataset counts:",
+                filtered_dataset_counts,
+            )
+            print(
+                "[prepare_data] Filtered trial type counts:",
+                filtered_trial_counts,
+            )
+
+    if filtered.empty:
+        available_datasets = sorted({
+            _canonicalize_dataset_name(value) for value in dataset_series.unique()
+        })
+        available_trial_types = sorted({value.lower() for value in trial_type_series.unique()})
+        raise ValueError(
+            "No trials remaining after filtering for testing trials in datasets: "
+            f"{sorted(dataset_candidates)}. "
+            f"Available dataset_name values after canonicalization: {available_datasets}. "
+            f"Available trial_type_name values: {available_trial_types}. "
+            f"Dataset column used: {dataset_column or 'not found'}. "
+            f"Trial type column used: {trial_type_column or 'not found'}"
+        )
+
+    traces = filtered[time_columns].to_numpy(dtype=float)
+
+    # Z-score per trial (row-wise standardization).
+    means = traces.mean(axis=1, keepdims=True)
+    stds = traces.std(axis=1, keepdims=True)
+    stds[stds == 0] = 1.0
+    zscored = (traces - means) / stds
+
+    metadata_columns = [col for col in filtered.columns if col not in time_columns]
+    metadata = filtered[metadata_columns].copy()
+
+    return PreparedData(traces=zscored, metadata=metadata, time_columns=list(time_columns))
+
+
+__all__ = ["PreparedData", "prepare_data"]

--- a/unsup/io_utils.py
+++ b/unsup/io_utils.py
@@ -1,0 +1,77 @@
+"""Helper utilities for writing artifacts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class ArtifactPaths:
+    base_dir: Path
+
+    def report_path(self, model_name: str) -> Path:
+        return self.base_dir / f"report_{model_name}.csv"
+
+    def cluster_path(self, model_name: str) -> Path:
+        return self.base_dir / f"trial_clusters_{model_name}.csv"
+
+    def variance_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"pca_variance_{model_name}.png"
+
+    def time_importance_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"time_importance_{model_name}.png"
+
+    def embedding_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"embedding_{model_name}.png"
+
+    def component_csv(self, model_name: str) -> Path:
+        return self.base_dir / f"motifs_{model_name}.csv"
+
+    def component_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"motifs_{model_name}.png"
+
+
+def ensure_output_dir(base: Path) -> ArtifactPaths:
+    base.mkdir(parents=True, exist_ok=True)
+    return ArtifactPaths(base_dir=base)
+
+
+def write_report(path: Path, metrics: Dict[str, object]) -> None:
+    df = pd.DataFrame([metrics])
+    df.to_csv(path, index=False)
+
+
+def write_clusters(path: Path, metadata: pd.DataFrame, labels: Iterable[int]) -> None:
+    out_df = metadata.copy()
+    out_df["cluster_label"] = list(labels)
+    out_df.to_csv(path, index=False)
+
+
+def write_time_importance(path: Path, importance_df: pd.DataFrame) -> None:
+    importance_df.sort_values("time_index", inplace=True)
+    importance_df.to_csv(path, index=False)
+
+
+def write_components(path: Path, time_points: Iterable[float], components: np.ndarray) -> None:
+    """Persist temporal motifs to CSV."""
+
+    df = pd.DataFrame(
+        components.T,
+        columns=[f"component_{idx}" for idx in range(1, components.shape[0] + 1)],
+    )
+    df.insert(0, "time_index", list(time_points))
+    df.to_csv(path, index=False)
+
+
+__all__ = [
+    "ArtifactPaths",
+    "ensure_output_dir",
+    "write_report",
+    "write_clusters",
+    "write_time_importance",
+    "write_components",
+]

--- a/unsup/metrics.py
+++ b/unsup/metrics.py
@@ -1,0 +1,43 @@
+"""Evaluation metrics for unsupervised models."""
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+from sklearn import metrics
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import StratifiedKFold, cross_val_score
+
+
+def compute_silhouette(embedding: np.ndarray, labels: np.ndarray) -> float | None:
+    """Compute silhouette score, excluding noise labels."""
+
+    mask = labels != -1
+    unique_labels = np.unique(labels[mask]) if mask.any() else np.array([])
+    if unique_labels.size < 2:
+        return None
+    return float(metrics.silhouette_score(embedding[mask], labels[mask]))
+
+
+def compute_ari(pred_labels: np.ndarray, true_labels: Optional[np.ndarray]) -> float | None:
+    if true_labels is None:
+        return None
+    if np.unique(true_labels).size < 2:
+        return None
+    return float(metrics.adjusted_rand_score(true_labels, pred_labels))
+
+
+def logistic_probe_cv(
+    features: np.ndarray,
+    labels: np.ndarray,
+    seed: Optional[int] = None,
+) -> float:
+    """Evaluate linear separability with logistic regression."""
+
+    classifier = LogisticRegression(max_iter=1000, random_state=seed)
+    cv = StratifiedKFold(n_splits=5, shuffle=True, random_state=seed)
+    scores = cross_val_score(classifier, features, labels, cv=cv, scoring="accuracy")
+    return float(np.mean(scores))
+
+
+__all__ = ["compute_silhouette", "compute_ari", "logistic_probe_cv"]

--- a/unsup/models/__init__.py
+++ b/unsup/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model backends for unsupervised clustering."""
+
+from . import pca_gmm, pca_hdbscan, pca_kmeans, reaction_profiles  # noqa: F401
+
+__all__ = ["pca_gmm", "pca_hdbscan", "pca_kmeans", "reaction_profiles"]

--- a/unsup/models/pca_gmm.py
+++ b/unsup/models/pca_gmm.py
@@ -1,0 +1,100 @@
+"""PCA + Gaussian mixture clustering pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+from sklearn.mixture import GaussianMixture
+
+from ..metrics import compute_ari, compute_silhouette, logistic_probe_cv
+from ..pca_core import PCAResults
+
+
+@dataclass
+class ModelOutputs:
+    labels: np.ndarray
+    metrics: Dict[str, float | int | None]
+
+
+def _candidate_range(n_samples: int, min_components: int, max_components: int) -> range:
+    if n_samples == 0:
+        return range(0)
+
+    upper = max(1, min(max_components, n_samples))
+    lower = max(1, min(min_components, upper))
+    if lower > upper:
+        lower = upper
+    return range(lower, upper + 1)
+
+
+def _select_gmm(
+    embedding: np.ndarray,
+    seed: Optional[int],
+    min_components: int,
+    max_components: int,
+) -> tuple[GaussianMixture, np.ndarray]:
+    candidates = _candidate_range(embedding.shape[0], min_components, max_components)
+
+    best_bic = np.inf
+    best_model: Optional[GaussianMixture] = None
+    best_labels: Optional[np.ndarray] = None
+
+    for n_components in candidates:
+        model = GaussianMixture(n_components=n_components, random_state=seed)
+        model.fit(embedding)
+        bic = model.bic(embedding)
+        labels = model.predict(embedding)
+        if bic < best_bic:
+            best_bic = bic
+            best_model = model
+            best_labels = labels
+
+    if best_model is None or best_labels is None:
+        fallback_components = max(1, min_components)
+        best_model = GaussianMixture(n_components=fallback_components, random_state=seed)
+        best_model.fit(embedding)
+        best_labels = best_model.predict(embedding)
+
+    return best_model, best_labels
+
+
+def run_model(
+    pca_results: PCAResults,
+    dataset_labels: Optional[np.ndarray] = None,
+    seed: Optional[int] = None,
+    min_components: int = 2,
+    max_components: int = 10,
+) -> ModelOutputs:
+    pcs_to_use = pca_results.pcs_80pct or 1
+    embedding = pca_results.scores[:, :pcs_to_use]
+
+    if embedding.shape[0] == 0:
+        raise ValueError("No samples available for Gaussian mixture clustering.")
+
+    model, labels = _select_gmm(
+        embedding,
+        seed=seed,
+        min_components=min_components,
+        max_components=max_components,
+    )
+
+    silhouette = compute_silhouette(embedding, labels)
+    ari = compute_ari(labels, dataset_labels)
+    logreg_acc = None
+    if dataset_labels is not None and np.unique(dataset_labels).size == 2:
+        logreg_acc = logistic_probe_cv(embedding, dataset_labels, seed=seed)
+
+    metrics_dict: Dict[str, float | int | None] = {
+        "n_clusters": int(len(np.unique(labels))),
+        "selected_components": int(model.n_components),
+        "noise_fraction": 0.0,
+        "silhouette": silhouette,
+        "ARI_vs_true": ari,
+        "logreg_cv_acc": logreg_acc,
+    }
+
+    return ModelOutputs(labels=labels, metrics=metrics_dict)
+
+
+__all__ = ["run_model", "ModelOutputs"]

--- a/unsup/models/pca_hdbscan.py
+++ b/unsup/models/pca_hdbscan.py
@@ -1,0 +1,59 @@
+"""PCA + density-based clustering pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+from sklearn.cluster import DBSCAN
+
+from ..metrics import compute_ari, compute_silhouette
+from ..pca_core import PCAResults
+
+try:  # Optional dependency
+    import hdbscan  # type: ignore
+except ImportError:  # pragma: no cover
+    hdbscan = None
+
+
+@dataclass
+class ModelOutputs:
+    labels: np.ndarray
+    metrics: Dict[str, float | int | None]
+
+
+def run_model(
+    pca_results: PCAResults,
+    dataset_labels: Optional[np.ndarray] = None,
+    min_cluster_size: int = 5,
+    seed: Optional[int] = None,
+) -> ModelOutputs:
+    pcs_to_use = pca_results.pcs_80pct or 1
+    embedding = pca_results.scores[:, :pcs_to_use]
+
+    if hdbscan is not None:
+        clusterer = hdbscan.HDBSCAN(min_cluster_size=min_cluster_size, prediction_data=False)
+        labels = clusterer.fit_predict(embedding)
+    else:
+        clusterer = DBSCAN(min_samples=min_cluster_size)
+        labels = clusterer.fit_predict(embedding)
+
+    silhouette = compute_silhouette(embedding, labels)
+    ari = compute_ari(labels, dataset_labels)
+
+    unique_labels = np.unique(labels)
+    cluster_labels = unique_labels[unique_labels != -1]
+    noise_fraction = float(np.mean(labels == -1))
+
+    metrics_dict: Dict[str, float | int | None] = {
+        "n_clusters": int(cluster_labels.size),
+        "noise_fraction": noise_fraction,
+        "silhouette": silhouette,
+        "ARI_vs_true": ari,
+        "logreg_cv_acc": None,
+    }
+
+    return ModelOutputs(labels=labels, metrics=metrics_dict)
+
+
+__all__ = ["run_model", "ModelOutputs"]

--- a/unsup/models/pca_kmeans.py
+++ b/unsup/models/pca_kmeans.py
@@ -1,0 +1,95 @@
+"""PCA + k-means clustering pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+from sklearn.metrics import silhouette_score
+from sklearn.cluster import KMeans
+
+from ..metrics import compute_ari, compute_silhouette
+from ..pca_core import PCAResults
+
+
+@dataclass
+class ModelOutputs:
+    labels: np.ndarray
+    metrics: Dict[str, float | int | None]
+
+
+def _candidate_range(n_samples: int, min_clusters: int, max_clusters: int) -> range:
+    if n_samples <= 1:
+        return range(1, min(2, n_samples + 1))
+
+    upper = max(2, min(max_clusters, n_samples))
+    lower = max(2, min(min_clusters, upper))
+    if lower > upper:
+        lower = upper
+    return range(lower, upper + 1)
+
+
+def _select_kmeans(
+    embedding: np.ndarray,
+    seed: Optional[int],
+    min_clusters: int,
+    max_clusters: int,
+) -> tuple[np.ndarray, int]:
+    candidates = _candidate_range(embedding.shape[0], min_clusters, max_clusters)
+
+    best_score = -np.inf
+    best_labels: Optional[np.ndarray] = None
+    best_k = max(1, min_clusters)
+
+    for k in candidates:
+        clusterer = KMeans(n_clusters=k, random_state=seed)
+        labels = clusterer.fit_predict(embedding)
+        if np.unique(labels).size < 2:
+            continue
+        score = silhouette_score(embedding, labels)
+        if score > best_score:
+            best_score = score
+            best_labels = labels
+            best_k = k
+
+    if best_labels is None:
+        fallback_k = min(max(1, min_clusters), embedding.shape[0])
+        clusterer = KMeans(n_clusters=fallback_k, random_state=seed)
+        best_labels = clusterer.fit_predict(embedding)
+        best_k = fallback_k
+
+    return best_labels, best_k
+
+
+def run_model(
+    pca_results: PCAResults,
+    dataset_labels: Optional[np.ndarray] = None,
+    seed: Optional[int] = None,
+    min_clusters: int = 2,
+    max_clusters: int = 10,
+) -> ModelOutputs:
+    pcs_to_use = pca_results.pcs_80pct or 1
+    embedding = pca_results.scores[:, :pcs_to_use]
+
+    if embedding.shape[0] == 0:
+        raise ValueError("No samples available for k-means clustering.")
+
+    labels, selected_k = _select_kmeans(
+        embedding, seed=seed, min_clusters=min_clusters, max_clusters=max_clusters
+    )
+
+    silhouette = compute_silhouette(embedding, labels)
+    ari = compute_ari(labels, dataset_labels)
+
+    metrics_dict: Dict[str, float | int | None] = {
+        "n_clusters": int(len(np.unique(labels))),
+        "selected_k": int(selected_k),
+        "noise_fraction": 0.0,
+        "silhouette": silhouette,
+        "ARI_vs_true": ari,
+        "logreg_cv_acc": None,
+    }
+    return ModelOutputs(labels=labels, metrics=metrics_dict)
+
+
+__all__ = ["run_model", "ModelOutputs"]

--- a/unsup/models/reaction_profiles.py
+++ b/unsup/models/reaction_profiles.py
@@ -1,0 +1,266 @@
+"""Odor-aligned reaction profiling models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+from sklearn.cluster import KMeans
+from sklearn.decomposition import NMF, PCA
+from sklearn.preprocessing import StandardScaler
+
+from ..metrics import compute_ari, compute_silhouette, logistic_probe_cv
+
+
+ODOR_ON_FRAME = 1230
+ODOR_OFF_FRAME = 2430
+MOTIF_BIN_SIZE = 30
+MAX_MOTIF_COMPONENTS = 5
+
+
+@dataclass
+class ReactionModelOutputs:
+    labels: np.ndarray
+    metrics: Dict[str, float | int | None]
+    embedding: np.ndarray
+    feature_names: list[str]
+    features: np.ndarray
+    component_time: Optional[np.ndarray] = None
+    components: Optional[np.ndarray] = None
+    component_weights: Optional[np.ndarray] = None
+
+
+def _slice(traces: np.ndarray, start: int, end: int) -> np.ndarray:
+    start = max(0, min(start, traces.shape[1]))
+    end = max(start, min(end, traces.shape[1]))
+    return traces[:, start:end]
+
+
+def _safe_stat(segment: np.ndarray, reducer) -> np.ndarray:
+    if segment.size == 0:
+        length = segment.shape[0] if segment.ndim > 0 else 0
+        return np.zeros(length, dtype=float)
+    return reducer(segment)
+
+
+def _segment_statistics(traces: np.ndarray, odor_on: int, odor_off: int) -> dict[str, np.ndarray]:
+    """Summarize only the odor-on and odor-off windows.
+
+    The caller has already aligned traces so that ``odor_on``/``odor_off``
+    encapsulate the stimulus presentation. We intentionally avoid calculating
+    any baseline statistics so that the model focuses exclusively on how the
+    flies behave during the odor presentation and the subsequent recovery
+    period.
+    """
+
+    response = _slice(traces, odor_on, odor_off)
+    recovery = _slice(traces, odor_off, traces.shape[1])
+
+    stats: dict[str, np.ndarray] = {}
+
+    stats["odor_mean"] = _safe_stat(response, lambda arr: arr.mean(axis=1))
+    stats["odor_std"] = _safe_stat(response, lambda arr: arr.std(axis=1))
+    stats["odor_max"] = _safe_stat(response, lambda arr: arr.max(axis=1))
+    stats["odor_min"] = _safe_stat(response, lambda arr: arr.min(axis=1))
+    stats["odor_duration"] = np.full(traces.shape[0], response.shape[1], dtype=float)
+    if response.size:
+        peak_indices = np.argmax(response, axis=1)
+        stats["odor_peak_latency"] = peak_indices.astype(float) / max(response.shape[1], 1)
+        stats["odor_auc"] = np.trapz(response, axis=1)
+    else:
+        stats["odor_peak_latency"] = np.zeros(traces.shape[0])
+        stats["odor_auc"] = np.zeros(traces.shape[0])
+
+    stats["post_mean"] = _safe_stat(recovery, lambda arr: arr.mean(axis=1))
+    stats["post_std"] = _safe_stat(recovery, lambda arr: arr.std(axis=1))
+    stats["post_min"] = _safe_stat(recovery, lambda arr: arr.min(axis=1))
+    stats["post_max"] = _safe_stat(recovery, lambda arr: arr.max(axis=1))
+    stats["post_auc"] = (
+        np.trapz(recovery, axis=1) if recovery.size else np.zeros(traces.shape[0])
+    )
+    stats["post_duration"] = np.full(traces.shape[0], recovery.shape[1], dtype=float)
+
+    stats["post_vs_odor_mean"] = stats["post_mean"] - stats["odor_mean"]
+    stats["post_auc_delta"] = stats["post_auc"] - stats["odor_auc"]
+
+    return stats
+
+
+def _aggregate_window(traces: np.ndarray, start: int, end: int, bin_size: int) -> tuple[np.ndarray, np.ndarray]:
+    window = _slice(traces, start, end)
+    if window.size == 0:
+        return np.empty((traces.shape[0], 0)), np.empty(0)
+
+    n_bins = int(np.ceil(window.shape[1] / bin_size))
+    aggregated = np.zeros((traces.shape[0], n_bins), dtype=float)
+    centers = np.zeros(n_bins, dtype=float)
+
+    for idx in range(n_bins):
+        s = idx * bin_size
+        e = min((idx + 1) * bin_size, window.shape[1])
+        aggregated[:, idx] = window[:, s:e].mean(axis=1)
+        centers[idx] = start + (s + e - 1) / 2.0
+
+    return aggregated, centers
+
+
+def _select_kmeans(features: np.ndarray, seed: Optional[int], min_clusters: int, max_clusters: int) -> tuple[np.ndarray, int]:
+    n_samples = features.shape[0]
+    if n_samples <= 1:
+        labels = np.zeros(n_samples, dtype=int)
+        return labels, 1
+
+    lower = max(2, min(min_clusters, n_samples))
+    upper = max(lower, min(max_clusters, n_samples))
+
+    best_labels: Optional[np.ndarray] = None
+    best_score = -np.inf
+    best_k = lower
+
+    for k in range(lower, upper + 1):
+        clusterer = KMeans(n_clusters=k, random_state=seed)
+        labels = clusterer.fit_predict(features)
+        if np.unique(labels).size < 2:
+            continue
+        score = compute_silhouette(features, labels)
+        if score is None:
+            continue
+        if score > best_score:
+            best_score = score
+            best_labels = labels
+            best_k = k
+
+    if best_labels is None:
+        clusterer = KMeans(n_clusters=lower, random_state=seed)
+        best_labels = clusterer.fit_predict(features)
+        best_k = lower
+
+    return best_labels, best_k
+
+
+def _cluster_reactions(
+    traces: np.ndarray,
+    dataset_labels: Optional[np.ndarray],
+    seed: Optional[int],
+    min_clusters: int,
+    max_clusters: int,
+) -> tuple[ReactionModelOutputs, dict[str, np.ndarray], np.ndarray, np.ndarray]:
+    odor_on = min(max(0, ODOR_ON_FRAME), traces.shape[1])
+    odor_off = min(max(odor_on + 1, ODOR_OFF_FRAME), traces.shape[1])
+
+    stats = _segment_statistics(traces, odor_on, odor_off)
+    feature_names = list(stats.keys())
+    feature_matrix = np.column_stack([stats[name] for name in feature_names])
+    feature_matrix = np.nan_to_num(feature_matrix, nan=0.0, posinf=0.0, neginf=0.0)
+
+    scaler = StandardScaler()
+    scaled = scaler.fit_transform(feature_matrix)
+
+    labels, selected_k = _select_kmeans(scaled, seed, min_clusters, max_clusters)
+
+    silhouette = compute_silhouette(scaled, labels)
+    ari = compute_ari(labels, dataset_labels)
+
+    metrics: Dict[str, float | int | None] = {
+        "n_clusters": int(np.unique(labels).size),
+        "selected_k": int(selected_k),
+        "noise_fraction": 0.0,
+        "silhouette": silhouette,
+        "ARI_vs_true": ari,
+        "logreg_cv_acc": None,
+    }
+
+    if dataset_labels is not None and np.unique(dataset_labels).size == 2:
+        metrics["logreg_cv_acc"] = logistic_probe_cv(scaled, dataset_labels, seed=seed)
+
+    projector = PCA(n_components=min(2, scaled.shape[1]), random_state=seed)
+    embedding = projector.fit_transform(scaled) if scaled.shape[1] >= 1 else np.zeros((scaled.shape[0], 2))
+
+    outputs = ReactionModelOutputs(
+        labels=labels,
+        metrics=metrics,
+        embedding=embedding,
+        feature_names=feature_names,
+        features=scaled,
+    )
+
+    motif_start = odor_on
+    motif_end = min(traces.shape[1], odor_off + 600)
+    aggregated, centers = _aggregate_window(traces, motif_start, motif_end, MOTIF_BIN_SIZE)
+
+    return outputs, stats, aggregated, centers
+
+
+def run_model_with_motifs(
+    traces: np.ndarray,
+    *,
+    dataset_labels: Optional[np.ndarray] = None,
+    seed: Optional[int] = None,
+    min_clusters: int = 2,
+    max_clusters: int = 10,
+) -> ReactionModelOutputs:
+    outputs, _, aggregated, centers = _cluster_reactions(
+        traces,
+        dataset_labels,
+        seed,
+        min_clusters,
+        max_clusters,
+    )
+
+    if aggregated.size == 0:
+        return outputs
+
+    shifted = aggregated - aggregated.min(axis=1, keepdims=True)
+    shifted += 1e-6
+
+    n_components = min(
+        MAX_MOTIF_COMPONENTS,
+        aggregated.shape[0],
+        aggregated.shape[1],
+    )
+    n_components = max(1, n_components)
+
+    model = NMF(
+        n_components=n_components,
+        init="nndsvda",
+        random_state=seed,
+        max_iter=1000,
+    )
+    weights = model.fit_transform(shifted)
+    components = model.components_
+
+    outputs.components = components
+    outputs.component_time = centers
+    outputs.component_weights = weights
+    return outputs
+
+
+def run_model_clusters_only(
+    traces: np.ndarray,
+    *,
+    dataset_labels: Optional[np.ndarray] = None,
+    seed: Optional[int] = None,
+    min_clusters: int = 2,
+    max_clusters: int = 10,
+) -> ReactionModelOutputs:
+    outputs, stats, aggregated, centers = _cluster_reactions(
+        traces,
+        dataset_labels,
+        seed,
+        min_clusters,
+        max_clusters,
+    )
+
+    # Preserve scaled features from clustering for downstream inspection.
+    outputs.feature_names = list(stats.keys())
+    outputs.components = None
+    outputs.component_time = centers if aggregated.size else None
+    outputs.component_weights = None
+    return outputs
+
+
+__all__ = [
+    "run_model_with_motifs",
+    "run_model_clusters_only",
+    "ReactionModelOutputs",
+]

--- a/unsup/pca_core.py
+++ b/unsup/pca_core.py
@@ -1,0 +1,76 @@
+"""Principal component analysis utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+import pandas as pd
+from sklearn.decomposition import PCA
+
+
+@dataclass
+class PCAResults:
+    """Bundle PCA outputs for downstream models and reporting."""
+
+    pca: PCA
+    scores: np.ndarray
+    explained_variance_ratio: np.ndarray
+    cumulative_variance: np.ndarray
+    pcs_80pct: int
+    pcs_90pct: int
+
+    @property
+    def components(self) -> np.ndarray:
+        return self.pca.components_
+
+
+def _select_components(cumulative: np.ndarray, threshold: float, cap: int) -> int:
+    above = np.where(cumulative >= threshold)[0]
+    if above.size == 0:
+        return min(cap, cumulative.size)
+    return min(cap, int(above[0] + 1))
+
+
+def compute_pca(
+    X: np.ndarray,
+    max_pcs: int = 10,
+    random_state: int | None = None,
+) -> PCAResults:
+    """Fit PCA and determine component counts for analysis."""
+
+    n_components = min(max_pcs, X.shape[1])
+    pca = PCA(n_components=n_components, random_state=random_state)
+    scores = pca.fit_transform(X)
+    explained = pca.explained_variance_ratio_
+    cumulative = np.cumsum(explained)
+
+    pcs_80 = _select_components(cumulative, 0.80, cap=max_pcs)
+    pcs_90 = _select_components(cumulative, 0.90, cap=min(5, n_components))
+
+    return PCAResults(
+        pca=pca,
+        scores=scores,
+        explained_variance_ratio=explained,
+        cumulative_variance=cumulative,
+        pcs_80pct=pcs_80,
+        pcs_90pct=pcs_90,
+    )
+
+
+def compute_time_importance(pca_results: PCAResults, time_columns: Sequence[str]) -> pd.DataFrame:
+    """Calculate mean absolute loadings across important PCs."""
+
+    if pca_results.pcs_90pct == 0:
+        raise ValueError("Unable to determine PCs covering 90% variance.")
+
+    top_components = pca_results.components[: pca_results.pcs_90pct]
+    importance = np.mean(np.abs(top_components), axis=0)
+
+    return pd.DataFrame({
+        "time_index": [int(col.split("_")[-1]) for col in time_columns],
+        "importance": importance,
+    })
+
+
+__all__ = ["PCAResults", "compute_pca", "compute_time_importance"]

--- a/unsup/plots.py
+++ b/unsup/plots.py
@@ -1,0 +1,114 @@
+"""Plotting utilities for unsupervised analysis."""
+from __future__ import annotations
+
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from .pca_core import PCAResults
+
+
+def plot_variance(pca_results: PCAResults, path: str) -> None:
+    indices = np.arange(1, len(pca_results.explained_variance_ratio) + 1)
+
+    fig, ax1 = plt.subplots(figsize=(6, 4))
+    ax1.bar(indices, pca_results.explained_variance_ratio, alpha=0.7, label="Explained variance")
+    ax1.set_xlabel("Principal Component")
+    ax1.set_ylabel("Variance ratio")
+    ax1.set_title("PCA explained variance")
+
+    ax2 = ax1.twinx()
+    ax2.plot(indices, pca_results.cumulative_variance, color="black", marker="o", label="Cumulative")
+    ax2.set_ylabel("Cumulative variance")
+    ax2.set_ylim(0, 1.05)
+
+    lines, labels = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines + lines2, labels + labels2, loc="best")
+
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+
+
+def plot_time_importance(importance_df: pd.DataFrame, path: str) -> None:
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.plot(importance_df["time_index"], importance_df["importance"], marker="o")
+    ax.set_xlabel("Time index")
+    ax.set_ylabel("Mean |loading|")
+    ax.set_title("Timepoint importance")
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+
+
+def plot_embedding(
+    embedding: np.ndarray,
+    labels: Sequence[int],
+    path: str,
+) -> None:
+    if embedding.shape[1] < 2:
+        padding = np.zeros((embedding.shape[0], 2 - embedding.shape[1]))
+        embedding = np.hstack([embedding, padding])
+    fig, ax = plt.subplots(figsize=(6, 4))
+    labels = np.asarray(labels)
+    mask_noise = labels == -1
+    unique_labels = np.unique(labels[~mask_noise])
+
+    if unique_labels.size == 0:
+        ax.scatter(embedding[:, 0], embedding[:, 1], s=20, c="grey", alpha=0.7)
+    else:
+        colors = plt.cm.get_cmap("tab10", unique_labels.size)
+        for idx, label in enumerate(unique_labels):
+            subset = labels == label
+            ax.scatter(
+                embedding[subset, 0],
+                embedding[subset, 1],
+                s=30,
+                color=colors(idx),
+                label=f"Cluster {label}",
+                alpha=0.8,
+            )
+        if mask_noise.any():
+            ax.scatter(
+                embedding[mask_noise, 0],
+                embedding[mask_noise, 1],
+                s=20,
+                color="lightgrey",
+                label="Noise",
+                alpha=0.6,
+                marker="x",
+            )
+
+    ax.set_xlabel("PC1")
+    ax.set_ylabel("PC2")
+    ax.set_title("PC1 vs PC2 embedding")
+    if unique_labels.size > 0 or mask_noise.any():
+        ax.legend(loc="best")
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+
+
+def plot_components(time_points: np.ndarray, components: np.ndarray, path: str) -> None:
+    fig, ax = plt.subplots(figsize=(6, 4))
+    for idx, pattern in enumerate(components):
+        ax.plot(time_points, pattern, label=f"Component {idx+1}")
+    ax.set_xlabel("Frame index")
+    ax.set_ylabel("Component magnitude")
+    ax.set_title("Odor-aligned motifs")
+    if components.shape[0] > 1:
+        ax.legend(loc="best")
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+
+
+__all__ = [
+    "plot_variance",
+    "plot_time_importance",
+    "plot_embedding",
+    "plot_components",
+]

--- a/unsup/run_all.py
+++ b/unsup/run_all.py
@@ -1,0 +1,305 @@
+"""Command line entry point for unsupervised clustering workflows."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+import warnings
+
+import numpy as np
+
+from .data_prep import prepare_data
+from .io_utils import (
+    ensure_output_dir,
+    write_clusters,
+    write_report,
+    write_time_importance,
+    write_components,
+)
+from .pca_core import compute_pca, compute_time_importance
+from .plots import plot_embedding, plot_time_importance, plot_variance, plot_components
+from .models import pca_gmm, pca_hdbscan, pca_kmeans, reaction_profiles
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run unsupervised clustering pipelines.")
+    parser.add_argument("--npy", type=Path, required=True, help="Path to the trial matrix npy file.")
+    parser.add_argument("--meta", type=Path, required=True, help="Path to the metadata JSON file.")
+    parser.add_argument("--out", type=Path, default=Path("outputs/unsup"), help="Output directory base path.")
+    parser.add_argument("--min-cluster-size", type=int, default=5, help="Minimum cluster size for HDBSCAN/DBSCAN.")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for reproducibility.")
+    parser.add_argument("--max-pcs", type=int, default=10, help="Maximum number of principal components to retain.")
+    parser.add_argument(
+        "--min-clusters",
+        type=int,
+        default=2,
+        help="Minimum number of clusters to evaluate for k-means/GMM selection.",
+    )
+    parser.add_argument(
+        "--max-clusters",
+        type=int,
+        default=10,
+        help="Maximum number of clusters to evaluate for k-means/GMM selection.",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=("EB", "3-octonol"),
+        help="Dataset names to include in the analysis.",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Print verbose diagnostics during data preparation and modeling.",
+    )
+    return parser.parse_args()
+
+
+def _collect_base_metrics(prepared, pca_results) -> Dict[str, int | float]:
+    return {
+        "n_trials": prepared.n_trials,
+        "n_time": prepared.n_timepoints,
+        "PCs_80pct": pca_results.pcs_80pct,
+        "PCs_90pct": pca_results.pcs_90pct,
+    }
+
+
+def _extract_labels(metadata) -> np.ndarray | None:
+    if "dataset_name" not in metadata.columns:
+        return None
+    labels = metadata["dataset_name"].to_numpy()
+    unique = np.unique(labels)
+    if unique.size != 2:
+        return None
+    mapping = {name: idx for idx, name in enumerate(sorted(unique))}
+    return np.vectorize(mapping.get)(labels)
+
+
+def main() -> None:
+    args = _parse_args()
+
+    if args.min_clusters < 1:
+        raise ValueError("--min-clusters must be at least 1.")
+    if args.max_clusters < args.min_clusters:
+        raise ValueError("--max-clusters must be greater than or equal to --min-clusters.")
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    run_dir = args.out / timestamp
+    artifacts = ensure_output_dir(run_dir)
+
+    # Suppress the scikit-learn deprecation warning that advises renaming the
+    # ``force_all_finite`` keyword argument to ``ensure_all_finite``. The
+    # warning originates from internal cross-validation helpers invoked by the
+    # clustering models we use, so filtering it here keeps the CLI output
+    # focused on actionable diagnostics for end users.
+    warnings.filterwarnings(
+        "ignore",
+        message="'force_all_finite' was renamed to 'ensure_all_finite'",
+        category=FutureWarning,
+        module=r"sklearn\..*",
+    )
+
+    if args.debug:
+        print(f"[run_all] Writing artifacts to: {run_dir}")
+
+    prepared = prepare_data(
+        args.npy,
+        args.meta,
+        target_datasets=args.datasets,
+        debug=args.debug,
+    )
+    if args.debug:
+        print(
+            "[run_all] Prepared traces:",
+            f"n_trials={prepared.n_trials}",
+            f"n_timepoints={prepared.n_timepoints}",
+        )
+
+    pca_results = compute_pca(prepared.traces, max_pcs=args.max_pcs, random_state=args.seed)
+    if args.debug:
+        print(
+            "[run_all] PCA complete:",
+            f"pcs_80pct={pca_results.pcs_80pct}",
+            f"pcs_90pct={pca_results.pcs_90pct}",
+            f"explained_var={np.round(pca_results.explained_variance_ratio, 4)}",
+        )
+    importance_df = compute_time_importance(pca_results, prepared.time_columns)
+    write_time_importance(run_dir / "timepoint_importance.csv", importance_df)
+
+    for model_name in (
+        "simple",
+        "flexible",
+        "noise_robust",
+        "reaction_motifs",
+        "reaction_clusters",
+    ):
+        plot_variance(pca_results, str(artifacts.variance_plot(model_name)))
+        plot_time_importance(
+            importance_df, str(artifacts.time_importance_plot(model_name))
+        )
+
+    labels_true = _extract_labels(prepared.metadata)
+
+    base_metrics = _collect_base_metrics(prepared, pca_results)
+
+    model_metrics: Dict[str, Dict[str, float | int | None]] = {}
+
+    # Simple model: PCA + KMeans
+    if args.debug:
+        print("[run_all] Running PCA+k-means model...")
+    simple_outputs = pca_kmeans.run_model(
+        pca_results,
+        dataset_labels=labels_true,
+        seed=args.seed,
+        min_clusters=args.min_clusters,
+        max_clusters=args.max_clusters,
+    )
+    embedding_simple = pca_results.scores[:, : max(2, pca_results.pcs_80pct or 2)]
+    plot_embedding(
+        embedding_simple[:, :2],
+        simple_outputs.labels,
+        str(artifacts.embedding_plot("simple")),
+    )
+
+    metrics_simple = {
+        **base_metrics,
+        "algo": "PCA+k-means",
+        **simple_outputs.metrics,
+    }
+    write_report(artifacts.report_path("simple"), metrics_simple)
+    write_clusters(artifacts.cluster_path("simple"), prepared.metadata, simple_outputs.labels)
+    model_metrics["simple"] = simple_outputs.metrics
+
+    # Flexible model: PCA + GMM
+    if args.debug:
+        print("[run_all] Running PCA+GMM model...")
+    flexible_outputs = pca_gmm.run_model(
+        pca_results,
+        dataset_labels=labels_true,
+        seed=args.seed,
+        min_components=args.min_clusters,
+        max_components=args.max_clusters,
+    )
+    embedding_flexible = pca_results.scores[:, : max(2, pca_results.pcs_80pct or 2)]
+    plot_embedding(
+        embedding_flexible[:, :2],
+        flexible_outputs.labels,
+        str(artifacts.embedding_plot("flexible")),
+    )
+
+    metrics_flexible = {
+        **base_metrics,
+        "algo": "PCA+GMM",
+        **flexible_outputs.metrics,
+    }
+    write_report(artifacts.report_path("flexible"), metrics_flexible)
+    write_clusters(artifacts.cluster_path("flexible"), prepared.metadata, flexible_outputs.labels)
+    model_metrics["flexible"] = flexible_outputs.metrics
+
+    # Noise-robust model: PCA + HDBSCAN/DBSCAN
+    if args.debug:
+        print("[run_all] Running PCA+HDBSCAN/DBSCAN model...")
+    noise_outputs = pca_hdbscan.run_model(
+        pca_results,
+        dataset_labels=labels_true,
+        min_cluster_size=args.min_cluster_size,
+        seed=args.seed,
+    )
+    embedding_noise = pca_results.scores[:, : max(2, pca_results.pcs_80pct or 2)]
+    plot_embedding(
+        embedding_noise[:, :2],
+        noise_outputs.labels,
+        str(artifacts.embedding_plot("noise_robust")),
+    )
+
+    algo_name = (
+        "PCA+HDBSCAN"
+        if getattr(pca_hdbscan, "hdbscan", None) is not None
+        else "PCA+DBSCAN"
+    )
+    metrics_noise = {
+        **base_metrics,
+        "algo": algo_name,
+        **noise_outputs.metrics,
+    }
+    write_report(artifacts.report_path("noise_robust"), metrics_noise)
+    write_clusters(artifacts.cluster_path("noise_robust"), prepared.metadata, noise_outputs.labels)
+    model_metrics["noise_robust"] = noise_outputs.metrics
+
+    # Odor reaction motif model
+    if args.debug:
+        print("[run_all] Running odor reaction motif model...")
+    reaction_motif_outputs = reaction_profiles.run_model_with_motifs(
+        prepared.traces,
+        dataset_labels=labels_true,
+        seed=args.seed,
+        min_clusters=args.min_clusters,
+        max_clusters=args.max_clusters,
+    )
+    plot_embedding(
+        reaction_motif_outputs.embedding,
+        reaction_motif_outputs.labels,
+        str(artifacts.embedding_plot("reaction_motifs")),
+    )
+    metrics_motifs = {
+        **base_metrics,
+        "algo": "Odor reaction motifs (NMF+k-means)",
+        **reaction_motif_outputs.metrics,
+    }
+    write_report(artifacts.report_path("reaction_motifs"), metrics_motifs)
+    write_clusters(
+        artifacts.cluster_path("reaction_motifs"),
+        prepared.metadata,
+        reaction_motif_outputs.labels,
+    )
+    model_metrics["reaction_motifs"] = reaction_motif_outputs.metrics
+    if (
+        reaction_motif_outputs.components is not None
+        and reaction_motif_outputs.component_time is not None
+    ):
+        write_components(
+            artifacts.component_csv("reaction_motifs"),
+            reaction_motif_outputs.component_time,
+            reaction_motif_outputs.components,
+        )
+        plot_components(
+            reaction_motif_outputs.component_time,
+            reaction_motif_outputs.components,
+            str(artifacts.component_plot("reaction_motifs")),
+        )
+
+    # Odor reaction cluster-only model
+    if args.debug:
+        print("[run_all] Running odor reaction cluster model...")
+    reaction_cluster_outputs = reaction_profiles.run_model_clusters_only(
+        prepared.traces,
+        dataset_labels=labels_true,
+        seed=args.seed,
+        min_clusters=args.min_clusters,
+        max_clusters=args.max_clusters,
+    )
+    plot_embedding(
+        reaction_cluster_outputs.embedding,
+        reaction_cluster_outputs.labels,
+        str(artifacts.embedding_plot("reaction_clusters")),
+    )
+    metrics_reaction = {
+        **base_metrics,
+        "algo": "Odor reaction features (k-means)",
+        **reaction_cluster_outputs.metrics,
+    }
+    write_report(artifacts.report_path("reaction_clusters"), metrics_reaction)
+    write_clusters(
+        artifacts.cluster_path("reaction_clusters"),
+        prepared.metadata,
+        reaction_cluster_outputs.labels,
+    )
+    model_metrics["reaction_clusters"] = reaction_cluster_outputs.metrics
+
+    if args.debug:
+        print("[run_all] Model metrics summary:", model_metrics)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- limit odor reaction feature extraction to odor-on and odor-off recovery windows without baseline statistics
- add additional odor-on/off descriptors and update motif aggregation to start at odor onset
- refresh README description to note the odor-on/off focus

## Testing
- python -m compileall unsup

------
https://chatgpt.com/codex/tasks/task_e_68dda3d8bbdc832d9851ee8a5ad41ab7