### PR TITLE
Add tested-odor PCA plots for key clusters

### DIFF
--- a/unsup/io_utils.py
+++ b/unsup/io_utils.py
@@ -58,6 +58,9 @@ class ArtifactPaths:
     def response_scores_csv(self, model_name: str) -> Path:
         return self.base_dir / f"odor_response_pca_scores_{model_name}.csv"
 
+    def response_auc_ranking_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_auc_ranking_{model_name}.png"
+
 
 def ensure_output_dir(base: Path) -> ArtifactPaths:
     base.mkdir(parents=True, exist_ok=True)

--- a/unsup/io_utils.py
+++ b/unsup/io_utils.py
@@ -25,6 +25,9 @@ class ArtifactPaths:
     def time_importance_plot(self, model_name: str) -> Path:
         return self.base_dir / f"time_importance_{model_name}.png"
 
+    def eigenvector_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"pca_eigenvectors_{model_name}.png"
+
     def embedding_plot(self, model_name: str) -> Path:
         return self.base_dir / f"embedding_{model_name}.png"
 
@@ -36,6 +39,24 @@ class ArtifactPaths:
 
     def average_trace_plot(self, model_name: str) -> Path:
         return self.base_dir / f"cluster_average_trace_{model_name}.png"
+
+    def response_auc_csv(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_auc_{model_name}.csv"
+
+    def response_auc_summary_csv(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_cluster_summary_{model_name}.csv"
+
+    def response_variance_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_variance_{model_name}.png"
+
+    def response_eigenvector_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_eigenvectors_{model_name}.png"
+
+    def response_embedding_plot(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_embedding_{model_name}.png"
+
+    def response_scores_csv(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_pca_scores_{model_name}.csv"
 
 
 def ensure_output_dir(base: Path) -> ArtifactPaths:

--- a/unsup/io_utils.py
+++ b/unsup/io_utils.py
@@ -61,6 +61,9 @@ class ArtifactPaths:
     def response_auc_ranking_plot(self, model_name: str) -> Path:
         return self.base_dir / f"odor_response_auc_ranking_{model_name}.png"
 
+    def response_auc_rankings_csv(self, model_name: str) -> Path:
+        return self.base_dir / f"odor_response_auc_rankings_{model_name}.csv"
+
 
 def ensure_output_dir(base: Path) -> ArtifactPaths:
     base.mkdir(parents=True, exist_ok=True)

--- a/unsup/odor_response.py
+++ b/unsup/odor_response.py
@@ -1,0 +1,202 @@
+"""Quantify odor-evoked responses using area-under-curve metrics."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .pca_core import PCAResults, compute_pca
+
+
+@dataclass
+class OdorResponseResults:
+    """Container bundling per-trial odor response metrics."""
+
+    metrics: pd.DataFrame
+    cluster_summary: pd.DataFrame
+    feature_matrix: np.ndarray | None
+    feature_timepoints: np.ndarray | None
+    trial_indices: np.ndarray
+    trial_labels: np.ndarray
+    trial_ids: np.ndarray
+
+
+def _validate_time_windows(
+    time_points: np.ndarray,
+    odor_on: float,
+    odor_off: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return boolean masks for baseline and odor intervals."""
+
+    baseline_mask = time_points < odor_on
+    odor_mask = (time_points >= odor_on) & (time_points <= odor_off)
+
+    if not baseline_mask.any():
+        raise ValueError(
+            "Baseline interval is empty; ensure odor_on exceeds earliest frame."
+        )
+    if not odor_mask.any():
+        raise ValueError(
+            "Odor interval is empty; check odor_on/odor_off against frame range."
+        )
+
+    return baseline_mask, odor_mask
+
+
+def _compute_frame_durations(time_values: np.ndarray) -> np.ndarray:
+    """Approximate dwell time for each sampled frame."""
+
+    if time_values.size == 1:
+        return np.ones_like(time_values, dtype=float)
+
+    diffs = np.diff(time_values.astype(float))
+    durations = np.empty_like(time_values, dtype=float)
+    durations[:-1] = diffs
+    durations[-1] = diffs[-1] if diffs.size else 1.0
+    durations[durations <= 0] = 1.0
+    return durations
+
+
+def evaluate_odor_response(
+    traces: np.ndarray,
+    labels: Sequence[int],
+    metadata_index: Iterable[object],
+    time_points: Sequence[float],
+    *,
+    odor_on: float,
+    odor_off: float,
+    target_clusters: Sequence[int] = (0, 1),
+) -> OdorResponseResults:
+    """Compute odor-evoked AUC metrics for select clusters."""
+
+    if traces.ndim != 2:
+        raise ValueError("traces must be two-dimensional")
+
+    labels_array = np.asarray(labels)
+    time_array = np.asarray(time_points, dtype=float)
+    baseline_mask, odor_mask = _validate_time_windows(time_array, odor_on, odor_off)
+
+    baseline = traces[:, baseline_mask]
+    odor_response = traces[:, odor_mask]
+    frame_durations = _compute_frame_durations(time_array[odor_mask])
+
+    baseline_mean = baseline.mean(axis=1)
+    baseline_std = baseline.std(axis=1, ddof=0)
+    threshold = baseline_mean + 4.0 * baseline_std
+
+    positive_response = odor_response - threshold[:, None]
+    positive_response[positive_response < 0] = 0.0
+
+    weighted_response = positive_response * frame_durations
+    auc_values = weighted_response.sum(axis=1)
+    total_duration = frame_durations.sum()
+    threshold_area = np.clip(np.abs(threshold) * total_duration, a_min=1e-8, a_max=None)
+    auc_ratio = auc_values / threshold_area
+
+    records: list[dict[str, object]] = []
+    selected_rows: list[int] = []
+    selected_labels: list[int] = []
+    selected_ids: list[object] = []
+    index_list = list(metadata_index)
+
+    target_set = {int(label) for label in target_clusters}
+
+    for row_idx, cluster_label in enumerate(labels_array):
+        if int(cluster_label) not in target_set:
+            continue
+        records.append(
+            {
+                "trial_index": index_list[row_idx],
+                "cluster_label": int(cluster_label),
+                "baseline_mean": float(baseline_mean[row_idx]),
+                "baseline_std": float(baseline_std[row_idx]),
+                "threshold": float(threshold[row_idx]),
+                "auc_above_threshold": float(auc_values[row_idx]),
+                "auc_ratio": float(auc_ratio[row_idx]),
+            }
+        )
+        selected_rows.append(row_idx)
+        selected_labels.append(int(cluster_label))
+        selected_ids.append(index_list[row_idx])
+
+    metrics_df = pd.DataFrame(records)
+    if metrics_df.empty:
+        metrics_df = pd.DataFrame(
+            columns=[
+                "rank",
+                "trial_index",
+                "cluster_label",
+                "baseline_mean",
+                "baseline_std",
+                "threshold",
+                "auc_above_threshold",
+                "auc_ratio",
+            ]
+        )
+    else:
+        metrics_df.sort_values("auc_ratio", ascending=False, inplace=True)
+        metrics_df.insert(0, "rank", np.arange(1, len(metrics_df) + 1))
+
+    summary_columns = [
+        "cluster_label",
+        "n_trials",
+        "mean_auc_ratio",
+        "median_auc_ratio",
+        "max_auc_ratio",
+    ]
+    summary_df = pd.DataFrame(columns=summary_columns)
+    if not metrics_df.empty:
+        summary_df = (
+            metrics_df.groupby("cluster_label")
+            .agg(
+                n_trials=("auc_ratio", "size"),
+                mean_auc_ratio=("auc_ratio", "mean"),
+                median_auc_ratio=("auc_ratio", "median"),
+                max_auc_ratio=("auc_ratio", "max"),
+            )
+            .reset_index()
+            .sort_values("mean_auc_ratio", ascending=False)
+        )
+        summary_df = summary_df[summary_columns]
+
+    feature_matrix: np.ndarray | None = None
+    feature_time: np.ndarray | None = None
+    if selected_rows:
+        feature_matrix = positive_response[selected_rows]
+        feature_time = time_array[odor_mask]
+
+    return OdorResponseResults(
+        metrics=metrics_df,
+        cluster_summary=summary_df,
+        feature_matrix=feature_matrix,
+        feature_timepoints=feature_time,
+        trial_indices=np.asarray(selected_rows, dtype=int),
+        trial_labels=np.asarray(selected_labels, dtype=int),
+        trial_ids=np.asarray(selected_ids, dtype=object),
+    )
+
+
+def run_response_pca(
+    feature_matrix: np.ndarray | None,
+    *,
+    max_pcs: int,
+    random_state: int | None = None,
+) -> PCAResults | None:
+    """Fit PCA on odor-response features when sufficient variance exists."""
+
+    if feature_matrix is None:
+        return None
+    if feature_matrix.shape[0] < 2 or feature_matrix.shape[1] < 2:
+        return None
+
+    col_std = feature_matrix.std(axis=0)
+    if np.allclose(col_std, 0):
+        return None
+
+    capped_pcs = min(max_pcs, feature_matrix.shape[1])
+    return compute_pca(feature_matrix, max_pcs=capped_pcs, random_state=random_state)
+
+
+__all__ = ["OdorResponseResults", "evaluate_odor_response", "run_response_pca"]

--- a/unsup/odor_response.py
+++ b/unsup/odor_response.py
@@ -21,6 +21,7 @@ class OdorResponseResults:
     trial_indices: np.ndarray
     trial_labels: np.ndarray
     trial_ids: np.ndarray
+    auc_ratios: np.ndarray
 
 
 def _validate_time_windows(
@@ -99,6 +100,7 @@ def evaluate_odor_response(
     selected_rows: list[int] = []
     selected_labels: list[int] = []
     selected_ids: list[object] = []
+    selected_auc_ratios: list[float] = []
     index_list = list(metadata_index)
 
     target_set = {int(label) for label in target_clusters}
@@ -120,6 +122,7 @@ def evaluate_odor_response(
         selected_rows.append(row_idx)
         selected_labels.append(int(cluster_label))
         selected_ids.append(index_list[row_idx])
+        selected_auc_ratios.append(float(auc_ratio[row_idx]))
 
     metrics_df = pd.DataFrame(records)
     if metrics_df.empty:
@@ -175,6 +178,7 @@ def evaluate_odor_response(
         trial_indices=np.asarray(selected_rows, dtype=int),
         trial_labels=np.asarray(selected_labels, dtype=int),
         trial_ids=np.asarray(selected_ids, dtype=object),
+        auc_ratios=np.asarray(selected_auc_ratios, dtype=float),
     )
 
 

--- a/unsup/plots.py
+++ b/unsup/plots.py
@@ -48,6 +48,39 @@ def plot_time_importance(importance_df: pd.DataFrame, path: str) -> None:
     plt.close(fig)
 
 
+def plot_pca_eigenvectors(
+    pca_results: PCAResults,
+    time_points: Sequence[float],
+    path: str,
+    *,
+    max_components: int = 5,
+    title: str | None = None,
+) -> None:
+    """Visualize leading PCA eigenvectors as temporal loadings."""
+
+    components = pca_results.components
+    if components.size == 0:
+        raise ValueError("PCA results contain no components to plot.")
+
+    n_components = min(max_components, components.shape[0])
+    times = np.asarray(time_points, dtype=float)
+    if times.size != components.shape[1]:
+        times = np.arange(1, components.shape[1] + 1)
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+    for idx in range(n_components):
+        ax.plot(times, components[idx], label=f"PC{idx+1}")
+
+    ax.set_xlabel("Frame index")
+    ax.set_ylabel("Loading weight")
+    ax.set_title(title or "PCA eigenvectors")
+    if n_components > 1:
+        ax.legend(loc="best")
+    fig.tight_layout()
+    fig.savefig(path, dpi=200)
+    plt.close(fig)
+
+
 def plot_embedding(
     embedding: np.ndarray,
     labels: Sequence[int],
@@ -280,6 +313,7 @@ def plot_cluster_traces(
 __all__ = [
     "plot_variance",
     "plot_time_importance",
+    "plot_pca_eigenvectors",
     "plot_embedding",
     "plot_cluster_odor_embedding",
     "plot_components",

--- a/unsup/run_all.py
+++ b/unsup/run_all.py
@@ -285,7 +285,7 @@ def main() -> None:
         odor_results = evaluate_odor_response(
             prepared.traces,
             simple_outputs.labels,
-            prepared.metadata.index,
+            prepared.metadata,
             time_points,
             odor_on=ODOR_ON_FRAME,
             odor_off=ODOR_OFF_FRAME,
@@ -301,7 +301,15 @@ def main() -> None:
         )
         ranking_columns = [
             column
-            for column in ("rank", "trial_index", "cluster_label", "auc_ratio")
+            for column in (
+                "rank",
+                "dataset",
+                "fly",
+                "trial_type",
+                "trial_label",
+                "cluster_label",
+                "auc_ratio",
+            )
             if column in odor_results.metrics.columns
         ]
         if ranking_columns:
@@ -347,7 +355,7 @@ def main() -> None:
                 ],
             )
             response_scores.insert(0, "cluster_label", odor_results.trial_labels)
-            response_scores.insert(0, "trial_index", odor_results.trial_ids)
+            response_scores.insert(0, "trial_descriptor", odor_results.trial_ids)
             response_scores.to_csv(
                 artifacts.response_scores_csv("simple"), index=False
             )

--- a/unsup/run_all.py
+++ b/unsup/run_all.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import re
 import warnings
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Mapping, Sequence, Tuple
 
 import numpy as np
 import pandas as pd
@@ -166,6 +166,323 @@ def _infer_testing_codes(metadata: pd.DataFrame) -> Tuple[pd.Series | None, str 
     return None, None
 
 
+def _evaluate_and_render_odor_response(
+    model_name: str,
+    traces: np.ndarray,
+    labels: Sequence[int],
+    metadata: pd.DataFrame,
+    time_points: np.ndarray,
+    artifacts: ArtifactPaths,
+    *,
+    odor_on: float,
+    odor_off: float,
+    target_clusters: Sequence[int],
+    cluster_colors: Mapping[int, str],
+    fallback_embedding: np.ndarray | None,
+    max_pcs: int,
+    seed: int,
+    debug: bool,
+):
+    try:
+        odor_results = evaluate_odor_response(
+            traces,
+            labels,
+            metadata,
+            time_points,
+            odor_on=odor_on,
+            odor_off=odor_off,
+            target_clusters=target_clusters,
+        )
+    except ValueError as exc:
+        if debug:
+            print(
+                "[run_all] Odor response evaluation failed (model=",
+                model_name,
+                "):",
+                exc,
+            )
+        return None
+
+    odor_results.metrics.to_csv(artifacts.response_auc_csv(model_name), index=False)
+
+    ranking_columns = [
+        column
+        for column in (
+            "rank",
+            "dataset",
+            "fly",
+            "trial_type",
+            "trial_label",
+            "cluster_label",
+            "auc_ratio",
+        )
+        if column in odor_results.metrics.columns
+    ]
+    if ranking_columns:
+        odor_results.metrics[ranking_columns].to_csv(
+            artifacts.response_auc_rankings_csv(model_name),
+            index=False,
+        )
+
+    odor_results.cluster_summary.to_csv(
+        artifacts.response_auc_summary_csv(model_name), index=False
+    )
+
+    plot_auc_ranking(
+        odor_results.metrics,
+        str(artifacts.response_auc_ranking_plot(model_name)),
+    )
+
+    response_embedding_data: np.ndarray | None = None
+    response_pca = None
+
+    if odor_results.feature_matrix is not None:
+        response_pca = run_response_pca(
+            odor_results.feature_matrix,
+            max_pcs=max_pcs,
+            random_state=seed,
+        )
+        if response_pca is not None:
+            plot_variance(
+                response_pca,
+                str(artifacts.response_variance_plot(model_name)),
+            )
+            eigentime = (
+                odor_results.feature_timepoints
+                if odor_results.feature_timepoints is not None
+                else np.arange(1, response_pca.components.shape[1] + 1)
+            )
+            plot_pca_eigenvectors(
+                response_pca,
+                eigentime,
+                str(artifacts.response_eigenvector_plot(model_name)),
+                title="Odor response PCA eigenvectors",
+            )
+            response_embedding_data = response_pca.scores[:, :2]
+
+            response_scores = pd.DataFrame(
+                response_pca.scores,
+                columns=[f"PC{idx+1}" for idx in range(response_pca.scores.shape[1])],
+            )
+            response_scores.insert(0, "cluster_label", odor_results.trial_labels)
+            response_scores.insert(0, "trial_descriptor", odor_results.trial_ids)
+            response_scores.to_csv(
+                artifacts.response_scores_csv(model_name), index=False
+            )
+        elif debug:
+            print(
+                "[run_all] Skipping odor response PCA due to insufficient variance",
+                f"(model={model_name}).",
+            )
+    elif debug and odor_results.metrics.empty:
+        print(
+            "[run_all] Odor response evaluation returned no target trials",
+            f"for model={model_name}.",
+        )
+
+    if response_embedding_data is None and fallback_embedding is not None:
+        fallback = np.asarray(fallback_embedding)
+        if fallback.ndim == 1:
+            fallback = fallback[:, None]
+        if fallback.shape[1] < 2:
+            padding = np.zeros((fallback.shape[0], 2 - fallback.shape[1]))
+            fallback = np.hstack([fallback, padding])
+        if odor_results.trial_indices.size > 0:
+            response_embedding_data = fallback[odor_results.trial_indices][:, :2]
+
+    if (
+        odor_results.auc_ratios.size > 0
+        and odor_results.trial_labels.size == odor_results.auc_ratios.size
+        and response_embedding_data is not None
+    ):
+        plot_embedding_by_auc(
+            response_embedding_data,
+            odor_results.trial_labels,
+            odor_results.auc_ratios,
+            str(artifacts.response_embedding_plot(model_name)),
+            cluster_colors=cluster_colors,
+        )
+
+    return odor_results
+
+
+def run_core_models(
+    prepared,
+    pca_results,
+    pca_features: pd.DataFrame,
+    time_points: np.ndarray,
+    labels_true: np.ndarray | None,
+    base_metrics: Dict[str, int | float],
+    artifacts: ArtifactPaths,
+    args,
+    cluster_outputs: Dict[str, Path],
+    model_metrics: Dict[str, Dict[str, float | int | None]],
+    *,
+    target_clusters: Sequence[int] = (0, 1),
+) -> Dict[str, Dict[str, object | None]]:
+    """Execute the primary simple/reaction clustering workflows."""
+
+    results: Dict[str, Dict[str, object | None]] = {}
+
+    if args.debug:
+        print("[run_all] Running PCA+k-means (simple) model...")
+    simple_outputs = pca_kmeans.run_model(
+        pca_results,
+        dataset_labels=labels_true,
+        seed=args.seed,
+        min_clusters=args.min_clusters,
+        max_clusters=args.max_clusters,
+    )
+    embedding_simple = pca_results.scores[:, : max(2, pca_results.pcs_80pct or 2)]
+    plot_embedding(
+        embedding_simple[:, :2],
+        simple_outputs.labels,
+        str(artifacts.embedding_plot("simple")),
+    )
+    plot_cluster_traces(
+        time_points,
+        prepared.traces,
+        simple_outputs.labels,
+        str(artifacts.average_trace_plot("simple")),
+    )
+
+    simple_odor_results = _evaluate_and_render_odor_response(
+        "simple",
+        prepared.traces,
+        simple_outputs.labels,
+        prepared.metadata,
+        time_points,
+        artifacts,
+        odor_on=ODOR_ON_FRAME,
+        odor_off=ODOR_OFF_FRAME,
+        target_clusters=target_clusters,
+        cluster_colors={0: "#b2182b", 1: "#2166ac"},
+        fallback_embedding=pca_results.scores,
+        max_pcs=args.max_pcs,
+        seed=args.seed,
+        debug=args.debug,
+    )
+
+    testing_codes, testing_column = _infer_testing_codes(prepared.metadata)
+    if testing_codes is not None:
+        if args.debug:
+            print(
+                "[run_all] Using metadata column for tested odor:",
+                testing_column,
+            )
+        aligned_codes = testing_codes.reindex(prepared.metadata.index)
+        for cluster_label in (1, 0):
+            plot_path = artifacts.base_dir / (
+                f"embedding_simple_cluster{cluster_label}_tested_odor.png"
+            )
+            plot_cluster_odor_embedding(
+                pca_features,
+                simple_outputs.labels,
+                aligned_codes,
+                cluster_label,
+                str(plot_path),
+                color_map={
+                    2: "red",
+                    4: "red",
+                    5: "red",
+                    1: "pink",
+                    3: "pink",
+                    6: "green",
+                    7: "blue",
+                    8: "black",
+                    9: "gray",
+                    10: "brown",
+                },
+                default_color="lightgrey",
+            )
+    elif args.debug:
+        print(
+            "[run_all] Unable to infer testing odor column for color-coded cluster plots.",
+            "Available columns:",
+            list(prepared.metadata.columns),
+        )
+
+    metrics_simple = {
+        **base_metrics,
+        "algo": "PCA+k-means",
+        **simple_outputs.metrics,
+    }
+    write_report(artifacts.report_path("simple"), metrics_simple)
+    simple_cluster_path = artifacts.cluster_path("simple")
+    write_clusters(
+        simple_cluster_path,
+        prepared.metadata,
+        simple_outputs.labels,
+        features=pca_features,
+    )
+    cluster_outputs["simple"] = simple_cluster_path
+    model_metrics["simple"] = simple_outputs.metrics
+    results["simple"] = {
+        "model_outputs": simple_outputs,
+        "odor_results": simple_odor_results,
+    }
+
+    if args.debug:
+        print("[run_all] Running odor reaction cluster model...")
+    reaction_cluster_outputs = reaction_profiles.run_model_clusters_only(
+        prepared.traces,
+        dataset_labels=labels_true,
+        seed=args.seed,
+        min_clusters=args.min_clusters,
+        max_clusters=args.max_clusters,
+    )
+    plot_embedding(
+        reaction_cluster_outputs.embedding,
+        reaction_cluster_outputs.labels,
+        str(artifacts.embedding_plot("reaction_clusters")),
+    )
+    plot_cluster_traces(
+        time_points,
+        prepared.traces,
+        reaction_cluster_outputs.labels,
+        str(artifacts.average_trace_plot("reaction_clusters")),
+    )
+
+    reaction_odor_results = _evaluate_and_render_odor_response(
+        "reaction_clusters",
+        prepared.traces,
+        reaction_cluster_outputs.labels,
+        prepared.metadata,
+        time_points,
+        artifacts,
+        odor_on=ODOR_ON_FRAME,
+        odor_off=ODOR_OFF_FRAME,
+        target_clusters=target_clusters,
+        cluster_colors={0: "#b2182b", 1: "#2166ac"},
+        fallback_embedding=reaction_cluster_outputs.embedding,
+        max_pcs=args.max_pcs,
+        seed=args.seed,
+        debug=args.debug,
+    )
+
+    metrics_reaction = {
+        **base_metrics,
+        "algo": "Odor reaction features (k-means)",
+        **reaction_cluster_outputs.metrics,
+    }
+    write_report(artifacts.report_path("reaction_clusters"), metrics_reaction)
+    reaction_cluster_path = artifacts.cluster_path("reaction_clusters")
+    write_clusters(
+        reaction_cluster_path,
+        prepared.metadata,
+        reaction_cluster_outputs.labels,
+        features=pca_features,
+    )
+    cluster_outputs["reaction_clusters"] = reaction_cluster_path
+    model_metrics["reaction_clusters"] = reaction_cluster_outputs.metrics
+    results["reaction_clusters"] = {
+        "model_outputs": reaction_cluster_outputs,
+        "odor_results": reaction_odor_results,
+    }
+
+    return results
+
+
 def main() -> None:
     args = _parse_args()
 
@@ -258,185 +575,19 @@ def main() -> None:
 
     model_metrics: Dict[str, Dict[str, float | int | None]] = {}
 
-    # Simple model: PCA + KMeans
-    if args.debug:
-        print("[run_all] Running PCA+k-means model...")
-    simple_outputs = pca_kmeans.run_model(
+    run_core_models(
+        prepared,
         pca_results,
-        dataset_labels=labels_true,
-        seed=args.seed,
-        min_clusters=args.min_clusters,
-        max_clusters=args.max_clusters,
-    )
-    embedding_simple = pca_results.scores[:, : max(2, pca_results.pcs_80pct or 2)]
-    plot_embedding(
-        embedding_simple[:, :2],
-        simple_outputs.labels,
-        str(artifacts.embedding_plot("simple")),
-    )
-    plot_cluster_traces(
+        pca_features,
         time_points,
-        prepared.traces,
-        simple_outputs.labels,
-        str(artifacts.average_trace_plot("simple")),
+        labels_true,
+        base_metrics,
+        artifacts,
+        args,
+        cluster_outputs,
+        model_metrics,
+        target_clusters=(0, 1),
     )
-
-    try:
-        odor_results = evaluate_odor_response(
-            prepared.traces,
-            simple_outputs.labels,
-            prepared.metadata,
-            time_points,
-            odor_on=ODOR_ON_FRAME,
-            odor_off=ODOR_OFF_FRAME,
-            target_clusters=(0, 1),
-        )
-    except ValueError as exc:
-        if args.debug:
-            print("[run_all] Odor response evaluation failed:", exc)
-        odor_results = None
-    else:
-        odor_results.metrics.to_csv(
-            artifacts.response_auc_csv("simple"), index=False
-        )
-        ranking_columns = [
-            column
-            for column in (
-                "rank",
-                "dataset",
-                "fly",
-                "trial_type",
-                "trial_label",
-                "cluster_label",
-                "auc_ratio",
-            )
-            if column in odor_results.metrics.columns
-        ]
-        if ranking_columns:
-            odor_results.metrics[ranking_columns].to_csv(
-                artifacts.response_auc_rankings_csv("simple"),
-                index=False,
-            )
-        odor_results.cluster_summary.to_csv(
-            artifacts.response_auc_summary_csv("simple"), index=False
-        )
-        plot_auc_ranking(
-            odor_results.metrics,
-            str(artifacts.response_auc_ranking_plot("simple")),
-        )
-
-    response_embedding_data: np.ndarray | None = None
-
-    if odor_results and odor_results.feature_matrix is not None:
-        response_pca = run_response_pca(
-            odor_results.feature_matrix,
-            max_pcs=args.max_pcs,
-            random_state=args.seed,
-        )
-        if response_pca is not None:
-            plot_variance(
-                response_pca,
-                str(artifacts.response_variance_plot("simple")),
-            )
-            plot_pca_eigenvectors(
-                response_pca,
-                odor_results.feature_timepoints
-                if odor_results.feature_timepoints is not None
-                else np.arange(1, response_pca.components.shape[1] + 1),
-                str(artifacts.response_eigenvector_plot("simple")),
-                title="Odor response PCA eigenvectors",
-            )
-            response_embedding_data = response_pca.scores[:, :2]
-
-            response_scores = pd.DataFrame(
-                response_pca.scores,
-                columns=[
-                    f"PC{idx+1}" for idx in range(response_pca.scores.shape[1])
-                ],
-            )
-            response_scores.insert(0, "cluster_label", odor_results.trial_labels)
-            response_scores.insert(0, "trial_descriptor", odor_results.trial_ids)
-            response_scores.to_csv(
-                artifacts.response_scores_csv("simple"), index=False
-            )
-        elif args.debug:
-            print(
-                "[run_all] Skipping odor response PCA due to insufficient variance."
-            )
-    elif args.debug and odor_results is not None:
-        print("[run_all] Odor response evaluation returned no target trials.")
-
-    if (
-        odor_results
-        and odor_results.auc_ratios.size > 0
-        and odor_results.trial_labels.size == odor_results.auc_ratios.size
-    ):
-        if response_embedding_data is None:
-            response_embedding_data = pca_results.scores[odor_results.trial_indices][:, :2]
-
-        plot_embedding_by_auc(
-            response_embedding_data,
-            odor_results.trial_labels,
-            odor_results.auc_ratios,
-            str(artifacts.response_embedding_plot("simple")),
-            cluster_colors={0: "#b2182b", 1: "#2166ac"},
-        )
-
-    testing_codes, testing_column = _infer_testing_codes(prepared.metadata)
-    if testing_codes is not None:
-        odor_color_map = {
-            2: "red",
-            4: "red",
-            5: "red",
-            1: "pink",
-            3: "pink",
-            6: "green",
-            7: "blue",
-            8: "black",
-            9: "gray",
-            10: "brown",
-        }
-        if args.debug:
-            print(
-                "[run_all] Using metadata column for tested odor:",
-                testing_column,
-            )
-        aligned_codes = testing_codes.reindex(prepared.metadata.index)
-        for cluster_label in (1, 0):
-            plot_path = artifacts.base_dir / (
-                f"embedding_simple_cluster{cluster_label}_tested_odor.png"
-            )
-            plot_cluster_odor_embedding(
-                pca_features,
-                simple_outputs.labels,
-                aligned_codes,
-                cluster_label,
-                str(plot_path),
-                color_map=odor_color_map,
-                default_color="lightgrey",
-            )
-    elif args.debug:
-        print(
-            "[run_all] Unable to infer testing odor column for color-coded cluster plots.",
-            "Available columns:",
-            list(prepared.metadata.columns),
-        )
-
-    metrics_simple = {
-        **base_metrics,
-        "algo": "PCA+k-means",
-        **simple_outputs.metrics,
-    }
-    write_report(artifacts.report_path("simple"), metrics_simple)
-    simple_cluster_path = artifacts.cluster_path("simple")
-    write_clusters(
-        simple_cluster_path,
-        prepared.metadata,
-        simple_outputs.labels,
-        features=pca_features,
-    )
-    cluster_outputs["simple"] = simple_cluster_path
-    model_metrics["simple"] = simple_outputs.metrics
 
     # Flexible model: PCA + GMM
     if args.debug:
@@ -570,43 +721,6 @@ def main() -> None:
             reaction_motif_outputs.components,
             str(artifacts.component_plot("reaction_motifs")),
         )
-
-    # Odor reaction cluster-only model
-    if args.debug:
-        print("[run_all] Running odor reaction cluster model...")
-    reaction_cluster_outputs = reaction_profiles.run_model_clusters_only(
-        prepared.traces,
-        dataset_labels=labels_true,
-        seed=args.seed,
-        min_clusters=args.min_clusters,
-        max_clusters=args.max_clusters,
-    )
-    plot_embedding(
-        reaction_cluster_outputs.embedding,
-        reaction_cluster_outputs.labels,
-        str(artifacts.embedding_plot("reaction_clusters")),
-    )
-    plot_cluster_traces(
-        time_points,
-        prepared.traces,
-        reaction_cluster_outputs.labels,
-        str(artifacts.average_trace_plot("reaction_clusters")),
-    )
-    metrics_reaction = {
-        **base_metrics,
-        "algo": "Odor reaction features (k-means)",
-        **reaction_cluster_outputs.metrics,
-    }
-    write_report(artifacts.report_path("reaction_clusters"), metrics_reaction)
-    reaction_cluster_path = artifacts.cluster_path("reaction_clusters")
-    write_clusters(
-        reaction_cluster_path,
-        prepared.metadata,
-        reaction_cluster_outputs.labels,
-        features=pca_features,
-    )
-    cluster_outputs["reaction_clusters"] = reaction_cluster_path
-    model_metrics["reaction_clusters"] = reaction_cluster_outputs.metrics
 
     if not args.skip_subclustering:
         for model_name, cluster_csv in cluster_outputs.items():

--- a/unsup/run_all.py
+++ b/unsup/run_all.py
@@ -299,6 +299,16 @@ def main() -> None:
         odor_results.metrics.to_csv(
             artifacts.response_auc_csv("simple"), index=False
         )
+        ranking_columns = [
+            column
+            for column in ("rank", "trial_index", "cluster_label", "auc_ratio")
+            if column in odor_results.metrics.columns
+        ]
+        if ranking_columns:
+            odor_results.metrics[ranking_columns].to_csv(
+                artifacts.response_auc_rankings_csv("simple"),
+                index=False,
+            )
         odor_results.cluster_summary.to_csv(
             artifacts.response_auc_summary_csv("simple"), index=False
         )


### PR DESCRIPTION
## Summary
- add a plotting helper that renders PC1 vs PC2 points for a cluster colored by tested odor groups
- detect testing odor codes from metadata and generate cluster 0/1 odor-colored scatter plots in the simple PCA+k-means workflow

## Testing
- python -m compileall unsup

------
https://chatgpt.com/codex/tasks/task_e_68e00b98b358832db4415d0763f86b74